### PR TITLE
Złodziej aut - poprawki i naprawy błędów (dodatkowo, z konieczności - naprawa /icons)

### DIFF
--- a/gamemodes/Mrucznik-RP.pwn
+++ b/gamemodes/Mrucznik-RP.pwn
@@ -5451,12 +5451,7 @@ PayDay()
 	}
     printf("-> Updating GangZones");
     Zone_GangUpdate(true);
-    printf("-> Removing Houses MapIcons");
 
-	for(new i; i<=dini_Int("Domy/NRD.ini", "NrDomow"); i++)
-	{
-		DestroyDynamicMapIcon(Dom[i][hIkonka]);
-	}
 	new hour,minuite,second;
 	new rand = random(80);
 	gettime(hour,minuite,second);

--- a/gamemodes/commands/cmd/deletedom.pwn
+++ b/gamemodes/commands/cmd/deletedom.pwn
@@ -49,7 +49,7 @@ YCMD:deletedom(playerid, params[], help)
 			{
 				dini_Remove(string);
 				DestroyDynamicPickup(Dom[kategoria][hPickup]);
-				DestroyDynamicMapIcon(Dom[kategoria][hIkonka]);
+				if(Dom[kategoria][hIkonka] != -1) DestroyDynamicMapIcon(Dom[kategoria][hIkonka]);
                 Dom[kategoria][hID] = 0;
 				Dom[kategoria][hDomNr] = 0;
 				Dom[kategoria][hZamek] = 0;
@@ -72,7 +72,7 @@ YCMD:deletedom(playerid, params[], help)
 				//Dom[kategoria][h3D_txt] = 0;
 				Dom[kategoria][hK_3D] = 0;
 				Dom[kategoria][hPickup] = 0;
-				Dom[kategoria][hIkonka] = 0;
+				Dom[kategoria][hIkonka] = -1;
 				Dom[kategoria][hPokoje] = 0;
 				Dom[kategoria][hPDW] = 0;
 				Dom[kategoria][hPW] = 0;

--- a/gamemodes/commands/cmd/icons.pwn
+++ b/gamemodes/commands/cmd/icons.pwn
@@ -32,17 +32,30 @@ YCMD:icons(playerid, params[], help)
 {
     if(IsPlayerConnected(playerid))
     {
+        new icon_type;
+
         for(new i; i<=dini_Int("Domy/NRD.ini", "NrDomow"); i++)
         {
             if(Dom[i][hKupiony] == 0)
             {
-                Dom[i][hIkonka] = CreateDynamicMapIcon(Dom[i][hWej_X], Dom[i][hWej_Y], Dom[i][hWej_Z], 31, 1, -1, -1, playerid, 125.0);
-            } else
+                icon_type = 31;
+            } 
+            else if(Dom[i][hWynajem] != 0)
             {
-                if(Dom[i][hWynajem] != 0)
-                {
-                    Dom[i][hIkonka] = CreateDynamicMapIcon(Dom[i][hWej_X], Dom[i][hWej_Y], Dom[i][hWej_Z], 32, 1, -1, -1, playerid, 125.0);
-                }
+                icon_type = 32;
+            }
+            else
+            {
+                continue;
+            }
+
+            if(Dom[i][hIkonka] == -1)
+            {
+                Dom[i][hIkonka] = CreateDynamicMapIcon(Dom[i][hWej_X], Dom[i][hWej_Y], Dom[i][hWej_Z], icon_type, 1, -1, -1, playerid, 125.0);
+            }
+            else if(!Streamer_IsInArrayData(STREAMER_TYPE_MAP_ICON, Dom[i][hIkonka], E_STREAMER_PLAYER_ID, playerid))
+            {
+                Streamer_AppendArrayData(STREAMER_TYPE_MAP_ICON, Dom[i][hIkonka], E_STREAMER_PLAYER_ID, playerid);
             }
         }
         MSGBOX_Show(playerid, "Ikony wlaczone!", MSGBOX_ICON_TYPE_OK);

--- a/gamemodes/commands/cmd/icons.pwn
+++ b/gamemodes/commands/cmd/icons.pwn
@@ -32,8 +32,18 @@ YCMD:icons(playerid, params[], help)
 {
     if(IsPlayerConnected(playerid))
     {
-        new icon_type;
+        new turn_on = 1;
+        for(new i; i<=dini_Int("Domy/NRD.ini", "NrDomow"); i++)
+        {
+            // Szukamy, czy gracz ma jak¹kolwiek ikonkê domu na mapie - je¿eli tak, to przyjmujemy, ¿e chce on wy³¹czyæ wszystkie ikony.
+            if(Dom[i][hIkonka] != -1 && Streamer_IsInArrayData(STREAMER_TYPE_MAP_ICON, Dom[i][hIkonka], E_STREAMER_PLAYER_ID, playerid))
+            {
+                turn_on = 0;
+                break;
+            }
+        }
 
+        new icon_type;
         for(new i; i<=dini_Int("Domy/NRD.ini", "NrDomow"); i++)
         {
             if(Dom[i][hKupiony] == 0)
@@ -49,16 +59,31 @@ YCMD:icons(playerid, params[], help)
                 continue;
             }
 
-            if(Dom[i][hIkonka] == -1)
+            if(turn_on)
             {
-                Dom[i][hIkonka] = CreateDynamicMapIcon(Dom[i][hWej_X], Dom[i][hWej_Y], Dom[i][hWej_Z], icon_type, 1, -1, -1, playerid, 125.0);
+                if(Dom[i][hIkonka] == -1)
+                {
+                    Dom[i][hIkonka] = CreateDynamicMapIcon(Dom[i][hWej_X], Dom[i][hWej_Y], Dom[i][hWej_Z], icon_type, 1, -1, -1, playerid, 125.0);
+                }
+                else if(!Streamer_IsInArrayData(STREAMER_TYPE_MAP_ICON, Dom[i][hIkonka], E_STREAMER_PLAYER_ID, playerid))
+                {
+                    Streamer_AppendArrayData(STREAMER_TYPE_MAP_ICON, Dom[i][hIkonka], E_STREAMER_PLAYER_ID, playerid);
+                }
             }
-            else if(!Streamer_IsInArrayData(STREAMER_TYPE_MAP_ICON, Dom[i][hIkonka], E_STREAMER_PLAYER_ID, playerid))
+            else if(Dom[i][hIkonka] != -1 && Streamer_IsInArrayData(STREAMER_TYPE_MAP_ICON, Dom[i][hIkonka], E_STREAMER_PLAYER_ID, playerid))
             {
-                Streamer_AppendArrayData(STREAMER_TYPE_MAP_ICON, Dom[i][hIkonka], E_STREAMER_PLAYER_ID, playerid);
+                Streamer_RemoveArrayData(STREAMER_TYPE_MAP_ICON, Dom[i][hIkonka], E_STREAMER_PLAYER_ID, playerid);
             }
         }
-        MSGBOX_Show(playerid, "Ikony wlaczone!", MSGBOX_ICON_TYPE_OK);
+
+        if(turn_on)
+        {
+            MSGBOX_Show(playerid, "Ikony domow ~g~wlaczone!", MSGBOX_ICON_TYPE_OK);
+        }
+        else
+        {
+            MSGBOX_Show(playerid, "Ikony domow ~r~wylaczone!", MSGBOX_ICON_TYPE_OK);
+        }
     }
     return 1;
 }

--- a/gamemodes/modules/zlodziej_aut/zlodziej_aut.hwn
+++ b/gamemodes/modules/zlodziej_aut/zlodziej_aut.hwn
@@ -43,5 +43,6 @@ forward FinishLSPDCarThiefTracking(playerid);
 forward UpdateCarThiefLSPDMapIcon(playerid);
 forward AntiTeleportCarThief(playerid);
 forward CarThiefMissionGoalTimer(playerid);
+forward CarThiefUnspawnStolenCar(veh_id, is_deluxe);
 
 //end

--- a/gamemodes/modules/zlodziej_aut/zlodziej_aut.pwn
+++ b/gamemodes/modules/zlodziej_aut/zlodziej_aut.pwn
@@ -124,7 +124,7 @@ ReloadDeluxeCarsForStealing()
 	for(new i = 0; i < sizeof(deluxe_cars_for_stealing_ids); i++)
 	{
 		new deluxe_veh_id = deluxe_cars_for_stealing_ids[i];
-		if(!used[deluxe_veh_id])
+		if(deluxe_veh_id != -1 && !used[deluxe_veh_id])
 		{
 			RemoveDeluxeCarForStealing(deluxe_veh_id);
 		}
@@ -139,6 +139,7 @@ ReloadCarForStealing(veh_id)
 	DestroyVehicle(veh_id);
 	AddCar(veh_id - 1);
 	SetVehicleNumberPlate(veh_id, "{1F9F06}M-RP");
+	Gas[veh_id] = GasMax;
 }
 
 GetLspdDetectThresholds(vehicleid, &short, &long)
@@ -362,6 +363,14 @@ UkradnijVerify(playerid, veh_id)
 	if(stole_a_car[playerid])
 	{
 		sendTipMessageEx(playerid, COLOR_GREY, "U¿y³eœ ju¿ /ukradnij w tym pojeŸdzie!");
+		return 0;
+	}
+
+	new Float:x, Float:y, Float:z;
+	GetPlayerPos(playerid, x, y, z);
+	if(x < 0.0 || y > -790)
+	{
+		sendTipMessageEx(playerid, COLOR_GREY, "U¿yj /ukradnij w Los Santos!");
 		return 0;
 	}
 

--- a/gamemodes/modules/zlodziej_aut/zlodziej_aut.pwn
+++ b/gamemodes/modules/zlodziej_aut/zlodziej_aut.pwn
@@ -548,14 +548,9 @@ CarThiefMissionGoal(playerid)
 	PlayerInfo[playerid][pCarTime] = cooldown;
 
 	RemovePlayerFromVehicleEx(playerid);
-	if(stole_a_car_lspd_bonus[playerid] == 3)
-	{
-		RemoveDeluxeCarForStealing(veh_id);
-	}
-	else
-	{
-		ReloadCarForStealing(veh_id);
-	}
+	SetVehicleParamsEx(veh_id, 0, 0, 0, 1, 0, 0, 0);
+	new is_deluxe = (stole_a_car_lspd_bonus[playerid] == 3);
+	SetTimerEx("CarThiefUnspawnStolenCar", 5000, false, "db", veh_id, is_deluxe);
 
 	EndCarThiefMission(playerid);
 

--- a/gamemodes/modules/zlodziej_aut/zlodziej_aut_timers.pwn
+++ b/gamemodes/modules/zlodziej_aut/zlodziej_aut_timers.pwn
@@ -67,4 +67,17 @@ public CarThiefMissionGoalTimer(playerid)
 	}
 }
 
+public CarThiefUnspawnStolenCar(veh_id, is_deluxe)
+{
+	SetVehicleParamsEx(veh_id, 0, 0, 0, 0, 0, 0, 0);
+	if(is_deluxe)
+	{
+		RemoveDeluxeCarForStealing(veh_id);
+	}
+	else
+	{
+		ReloadCarForStealing(veh_id);
+	}
+}
+
 //end

--- a/gamemodes/system/funkcje.pwn
+++ b/gamemodes/system/funkcje.pwn
@@ -5944,7 +5944,7 @@ StworzDom(playerid, interior, oplata)
 		Dom[dld][hS_A10] = 0;
 		Dom[dld][hS_A11] = 0;
 	    Dom[dld][hPickup] = CreateDynamicPickup(1273, 1, Dom[dld][hWej_X], Dom[dld][hWej_Y], Dom[dld][hWej_Z], -1, -1, -1, 125.0);
-	    Dom[dld][hIkonka] = -1
+	    Dom[dld][hIkonka] = -1;
 	    //Dom[dld][hIkonka] = CreateDynamicMapIcon(Dom[dld][hWej_X], Dom[dld][hWej_Y], Dom[dld][hWej_Z], 31, 1, -1, -1, -1, 125.0);
 		dini_IntSet("Domy/NRD.ini", "NrDomow", dld);
 		new intcena = IntInfo[Dom[dld][hDomNr]][Cena];

--- a/gamemodes/system/funkcje.pwn
+++ b/gamemodes/system/funkcje.pwn
@@ -5562,6 +5562,7 @@ ZaladujDomy()
 				Dom[i][hS_A9] = dini_Int(string, "S_A9");
 				Dom[i][hS_A10] = dini_Int(string, "S_A10");
 				Dom[i][hS_A11] = dini_Int(string, "S_A11");
+				Dom[i][hIkonka] = -1;
 				if(Dom[i][hKupiony] == 0)
 				{
 				    Dom[i][hPickup] = CreateDynamicPickup(1273, 1, Dom[i][hWej_X], Dom[i][hWej_Y], Dom[i][hWej_Z], -1, -1, -1, 125.0);
@@ -5943,7 +5944,8 @@ StworzDom(playerid, interior, oplata)
 		Dom[dld][hS_A10] = 0;
 		Dom[dld][hS_A11] = 0;
 	    Dom[dld][hPickup] = CreateDynamicPickup(1273, 1, Dom[dld][hWej_X], Dom[dld][hWej_Y], Dom[dld][hWej_Z], -1, -1, -1, 125.0);
-	    Dom[dld][hIkonka] = CreateDynamicMapIcon(Dom[dld][hWej_X], Dom[dld][hWej_Y], Dom[dld][hWej_Z], 31, 1, -1, -1, -1, 125.0);
+	    Dom[dld][hIkonka] = -1
+	    //Dom[dld][hIkonka] = CreateDynamicMapIcon(Dom[dld][hWej_X], Dom[dld][hWej_Y], Dom[dld][hWej_Z], 31, 1, -1, -1, -1, 125.0);
 		dini_IntSet("Domy/NRD.ini", "NrDomow", dld);
 		new intcena = IntInfo[Dom[dld][hDomNr]][Cena];
 		new Float:koxX = mnoznik/10;
@@ -6002,9 +6004,9 @@ Dom_ChangeInt(playerid, dld, interior)
 	Dom[dld][hCena] = floatround(cenadomu, floatround_ceil);
 
     DestroyDynamicPickup(Dom[dld][hPickup]);
-	if(Dom[dld][hIkonka] != 0) DestroyDynamicMapIcon(Dom[dld][hIkonka]);
+	if(Dom[dld][hIkonka] != -1) DestroyDynamicMapIcon(Dom[dld][hIkonka]);
     Dom[dld][hPickup] = CreateDynamicPickup(1239, 1, Dom[dld][hWej_X], Dom[dld][hWej_Y], Dom[dld][hWej_Z], -1, -1, -1, 125.0);
-    Dom[dld][hIkonka] = 0;
+    Dom[dld][hIkonka] = -1;
 
 	format(string, sizeof(string), "Zmiana Interioru - OK. || Dom %d || NrDom %d || Interior: %d || Cena %d", dld, Dom[dld][hDomNr], interior, Dom[dld][hCena]);
 	SendClientMessage(playerid, COLOR_NEWS, string);
@@ -6255,7 +6257,8 @@ L_StworzDom(playerid, kategoria, oplata)
 		Dom[dld][hS_A10] = 0;
 		Dom[dld][hS_A11] = 0;
 		Dom[dld][hPickup] = CreateDynamicPickup(1273, 1, Dom[dld][hWej_X], Dom[dld][hWej_Y], Dom[dld][hWej_Z], -1, -1, -1, 125.0);
-	    Dom[dld][hIkonka] = CreateDynamicMapIcon(Dom[dld][hWej_X], Dom[dld][hWej_Y], Dom[dld][hWej_Z], 31, 1, -1, -1, -1, 125.0);
+	    //Dom[dld][hIkonka] = CreateDynamicMapIcon(Dom[dld][hWej_X], Dom[dld][hWej_Y], Dom[dld][hWej_Z], 31, 1, -1, -1, -1, 125.0);
+	    Dom[dld][hIkonka] = -1;
 		dini_IntSet("Domy/NRD.ini", "NrDomow", dld);
 		new intcena = IntInfo[Dom[dld][hDomNr]][Cena];
 		new Float:koxX = mnoznik/10;
@@ -6333,9 +6336,9 @@ KupowanieDomu(playerid, dom, platnosc)
 		Dom[dom][hKupiony] = 1;
 		Dom[dom][hUID_W] = PlayerInfo[playerid][pUID];
 		DestroyDynamicPickup(Dom[dom][hPickup]);
-		DestroyDynamicMapIcon(Dom[dom][hIkonka]);
+		if(Dom[dom][hIkonka] != -1) DestroyDynamicMapIcon(Dom[dom][hIkonka]);
 	    Dom[dom][hPickup] = CreateDynamicPickup(1239, 1, Dom[dom][hWej_X], Dom[dom][hWej_Y], Dom[dom][hWej_Z], -1, -1, -1, 125.0);
-	    Dom[dom][hIkonka] = 0;
+	    Dom[dom][hIkonka] = -1;
 	    SetPlayerPos(playerid, Dom[dom][hInt_X], Dom[dom][hInt_Y], Dom[dom][hInt_Z]);
 	    SetPlayerInterior(playerid, Dom[dom][hInterior]);
 	    SetPlayerVirtualWorld(playerid, Dom[dom][hVW]);
@@ -6444,9 +6447,9 @@ ZlomowanieDomu(playerid, dom)
 		Dom[dom][hS_A11] = 0;
 		Dom[dom][hZbrojownia] = 0;
 		DestroyDynamicPickup(Dom[dom][hPickup]);
-		DestroyDynamicMapIcon(Dom[dom][hIkonka]);
+		if(Dom[dom][hIkonka] != -1) DestroyDynamicMapIcon(Dom[dom][hIkonka]);
 	    Dom[dom][hPickup] = CreateDynamicPickup(1273, 1, Dom[dom][hWej_X], Dom[dom][hWej_Y], Dom[dom][hWej_Z], -1, -1, -1, 125.0);
-	    Dom[dom][hIkonka] = CreateDynamicMapIcon(Dom[dom][hWej_X], Dom[dom][hWej_Y], Dom[dom][hWej_Z], 31, 1, -1, -1, -1, 125.0);
+	    Dom[dom][hIkonka] = -1;
 		ZapiszDom(dom);
 		//
 		if(playerid != 9999)

--- a/gamemodes/system/funkcje.pwn
+++ b/gamemodes/system/funkcje.pwn
@@ -879,10 +879,7 @@ public CountDownVehsRespawn()
 			{
 				if(v <= CAR_End)
 				{
-					DestroyVehicle(v);
-					carselect = GetRandomVehicleForStealingModel();
-					AddCar(v - 1);
-					SetVehicleNumberPlate(v, "{1F9F06}M-RP");
+					ReloadCarForStealing(v);
 				}
 				else
 				{
@@ -7912,6 +7909,7 @@ AddCar(car)
 {
 	new randcol = random(126);
 	new randcol2 = 1;
+	new carselect = GetRandomVehicleForStealingModel();
 	new id = AddStaticVehicleEx(RandCars[carselect][0], CarSpawns[car][pos_x], CarSpawns[car][pos_y], CarSpawns[car][pos_z], CarSpawns[car][z_angle], randcol, randcol2, -1);
 	return id;
 }
@@ -11841,7 +11839,7 @@ public TourCamera(playerid, step)
 
 GetRandomVehicleForStealingModel()
 {
-	new randa = random(53);
+	new randa = true_random(53);
 	new model;
 
 	if(randa == 0)
@@ -11871,7 +11869,6 @@ ZaladujSamochodyDoKradziezy()
 
     for(new i = 0; i < 165; i++)
 	{
-		carselect = GetRandomVehicleForStealingModel();
         id = AddCar(i);
     }
 

--- a/gamemodes/system/zmienne.pwn
+++ b/gamemodes/system/zmienne.pwn
@@ -1026,7 +1026,6 @@ new SpamujeMechanik[MAX_PLAYERS];//mechanik
 new AntySpam[MAX_PLAYERS];
 new OdpalanieSpam[MAX_PLAYERS];//OdpalanieSpam
 new DomOgladany[MAX_PLAYERS];//SYSTEM DOMÓW BY MRUCZNIK
-new carselect;
 new cbjstore[128];
 new motd[256];
 new ghour = 0;


### PR DESCRIPTION
Poprawki do złodzieja aut:
- naprawa buga z autami deluxe, które się nie respawnowały po pierwszej kradzieży albo respawnowały się jako nieprawidłowe modele;
- misji złodzieja aut nie można rozpoczynać poza LS (było to wykorzystywane, by LSPD nie zdążyło dojechać - mimo wszystko gramy głównie w LS);
- pojazdy do kradzieży są tankowane do pełna przy każdym respawnie i po zakończeniu misji złodzieja;
- naprawa buga, polegającego na tym, że pojazd nie zmieniał poprawnie modelu przy zakończeniu misji (nie było to losowe, tylko zawsze był ten sam jeden model, który zmieniał się przy respawnie);
- znikające ikonki oznaczające dziuplę na mapie przy PayDay;
- zdarzający się czasem kick od AC przy dojechaniu do mety.

Dodatkowo:
- naprawa /icons - od teraz działa to poprawnie (włącza i wyłącza ikonki na mapie, dotychczas tylko włączało i do tego bez sensu tworzyło ikony osobno dla każdego gracza) - ciekawostka: przez to znikał marker złodzieja na mapie (kto by się spodziewał, co xD?).