### PR TITLE
Quality of Life napadu - trzeci etap ucieczki

### DIFF
--- a/gamemodes/modules/napady/napady.def
+++ b/gamemodes/modules/napady/napady.def
@@ -27,9 +27,9 @@
 #define HEIST_MINIMUMLSPD       4 // onDuty
 #define HEIST_PAYOUT            55000 // gwarantowana dzia³ka
 #define HEIST_RANDPAYOUT        25000 // dodatek do wygranej, losowa liczba
-#define HEIST_STEAL_TIME        3 * 60 // etap stacjonarny w sekundach
-#define HEIST_ESCAPE_TIME       10 * 49 // iloœæ sekund do wygrania etapu ucieczki i gwarancji otrzymiania pieniêdzy
-#define HEIST_COOLDOWNS         28 // iloœæ minut do kolejnego napadu, globalna blokada
+#define HEIST_STEAL_TIME        3 * 80 // etap stacjonarny w sekundach
+#define HEIST_ESCAPE_TIME       10 * 35 // iloœæ sekund do wygrania etapu wolnej ucieczki, przed 30 sekundowym(3 potwierdzenia x 10s) checkiem czy LSPD jest w poblizu
+#define HEIST_COOLDOWNS         35 // iloœæ minut do kolejnego napadu, globalna blokada
 #define HEIST_MSG_STEAL         1
 #define HEIST_MSG_ESCAPE        2
 #define HEIST_MSG_GPSUPDATE     3

--- a/gamemodes/modules/napady/napady.def
+++ b/gamemodes/modules/napady/napady.def
@@ -23,14 +23,15 @@
 
 //------------------<[ Makra: ]>-------------------
 //------------------<[ Define: ]>-------------------
-#define HEIST_ZONESCOUNT    1 // iloœæ HeistZone[][]
-#define HEIST_MINIMUMLSPD   4 // onDuty
-#define HEIST_PAYOUT        55000 // gwarantowana dzia³ka
-#define HEIST_RANDPAYOUT    25000 // dodatek do wygranej, losowa liczba
-#define HEIST_STEAL_TIME    3 * 60 // etap stacjonarny w sekundach
-#define HEIST_ESCAPE_TIME   10 * 49 // iloœæ sekund do wygrania etapu ucieczki i gwarancji otrzymiania pieniêdzy
-#define HEIST_COOLDOWNS     28 // iloœæ minut do kolejnego napadu, globalna blokada
-#define HEIST_MSG_STEAL     1
-#define HEIST_MSG_ESCAPE    2
-#define HEIST_MSG_GPSUPDATE 3
+#define HEIST_ZONESCOUNT        1 // iloœæ HeistZone[][]
+#define HEIST_MINIMUMLSPD       4 // onDuty
+#define HEIST_PAYOUT            55000 // gwarantowana dzia³ka
+#define HEIST_RANDPAYOUT        25000 // dodatek do wygranej, losowa liczba
+#define HEIST_STEAL_TIME        3 * 60 // etap stacjonarny w sekundach
+#define HEIST_ESCAPE_TIME       10 * 49 // iloœæ sekund do wygrania etapu ucieczki i gwarancji otrzymiania pieniêdzy
+#define HEIST_COOLDOWNS         28 // iloœæ minut do kolejnego napadu, globalna blokada
+#define HEIST_MSG_STEAL         1
+#define HEIST_MSG_ESCAPE        2
+#define HEIST_MSG_GPSUPDATE     3
+#define HEIST_MSG_RETURNTOLS    4
 //end

--- a/gamemodes/modules/napady/napady.hwn
+++ b/gamemodes/modules/napady/napady.hwn
@@ -35,6 +35,7 @@ new Heist_NotifyPoliceCooldown = 10; // 10 = 30s cooldown
 new Heist_AttackersCount = 0; 
 new Heist_AttackersCounter = 0;
 new Heist_Steal_Countdown = 0;
+new Heist_PursuitCounter = 0;
 new Heist_HeistOFF = 0; // Globalna blokada, mozliwosc nalozenia przez administracje
 enum eHeistZones
 {

--- a/gamemodes/modules/napady/napady.pwn
+++ b/gamemodes/modules/napady/napady.pwn
@@ -45,6 +45,8 @@ Heist_EligibleToContinue(attackerid)
 		return 0;
 	if(Kajdanki_JestemSkuty[playerid] > 0)
 		return 0;
+	if(!IsPlayerConnected(playerid))
+		return 0;
 	
 	return 1;
 }
@@ -124,7 +126,7 @@ Heist_UpdateMapIcon()
 	GetVehiclePos(Heist_CurrentVehicleid, x, y, z);
 	foreach(new i : Player)
 	{
-		if(IsPlayerConnected(i) && OnDuty[i] && (PlayerInfo[i][pLider] == FRAC_LSPD || PlayerInfo[i][pMember] == FRAC_LSPD || leader == FRAC_FBI || member == FRAC_FBI))
+		if(IsPlayerConnected(i) && OnDuty[i] && (PlayerInfo[i][pLider] == FRAC_LSPD || PlayerInfo[i][pMember] == FRAC_LSPD || PlayerInfo[i][pMember] == FRAC_FBI || PlayerInfo[i][pLider] == FRAC_FBI))
 		{
 			if(IsValidDynamicMapIcon(Heist_Icons[i]))
 			{
@@ -328,6 +330,21 @@ Heist_ProcessEscape()
 	Heist_Notify(HEIST_MSG_GPSUPDATE);
 }
 
-
+Heist_ProcessLosePursuit()
+{
+	new playerid;
+	for(new i = 0; i < Heist_AttackersCount; i++)
+	{
+		playerid = Heist_Attackers[i];
+		if(playerid != -1)
+		{
+			SendClientMessage(playerid, COLOR_RED, ">> Ucieknij jak najdalej od LSPD by zakoñczyæ napad!");
+			PlayerPlaySound(playerid, 1149, 0.0, 0.0, 0.0);
+		}
+	}
+	KillTimer(Heist_Timers);
+	Heist_Timers = SetTimer("Heist_LosePursuit",10000,true);
+	Heist_UpdateMapIcon();
+}
 //end
 

--- a/gamemodes/modules/napady/napady_timers.pwn
+++ b/gamemodes/modules/napady/napady_timers.pwn
@@ -45,6 +45,7 @@ public Heist_ClearData(attackerid)
 	{
 		Heist_AttackersCount = 0;
 		Heist_AttackersCounter = 0;
+		Heist_PursuitCounter = 0;
 		for(new i = 0; i < 4; i++)
 		{
 			Heist_Attackers[i] = -1;
@@ -123,7 +124,7 @@ public Heist_Escape()
 	{
 		Heist_Lost();
 	}
-	if(Heist_MapIconCounter == 10)
+	if(Heist_MapIconCounter == 2)
 	{
 		Heist_UpdateMapIcon();
 		Heist_MapIconCounter = 0;
@@ -164,6 +165,67 @@ public Heist_Escape()
 	if(Heist_Steal_Countdown > 0)
 		Heist_Steal_Countdown -= 10;
 	else
+	{
+		Heist_ProcessLosePursuit();
+	}
+}
+
+forward Heist_LosePursuit();
+public Heist_LosePursuit()
+{
+	if(Heist_AttackersCounter < 1)
+	{
+		Heist_Lost();
+	}
+	new Float:vehHP;
+	GetVehicleHealth(Heist_CurrentVehicleid, vehHP);
+	if(vehHP <= 251.0)
+	{
+		Heist_Lost();
+	}
+	if(Heist_MapIconCounter == 5)
+	{
+		Heist_UpdateMapIcon();
+		Heist_MapIconCounter = 0;
+	}
+
+	new warning[48];
+	new time;
+	for(new i = 0; i < Heist_AttackersCount; i++)
+	{
+		if(Heist_Attackers[i] == -1) continue;
+		if(!Heist_EligibleToContinue(i))
+		{
+			Heist_Remove(i);
+			continue;
+		}
+
+		if(!IsPlayerInVehicle(Heist_Attackers[i], Heist_CurrentVehicleid))
+		{
+			if(Heist_AttackerWarnCount[i] < 4)
+			{
+				time = 5 * (4 - Heist_AttackerWarnCount[i]);
+				Heist_AttackerWarnCount[i]++;
+				format(warning, sizeof(warning), "Wróc do swojego auta! Masz na to %d sekund!", time);
+				SendClientMessage(Heist_Attackers[i], COLOR_LIGHTRED, warning);
+			}
+			else
+				Heist_Remove(i);
+			continue;
+		}
+		else if(Heist_AttackerWarnCount[i] > 0)
+			Heist_AttackerWarnCount[i] = 0;
+		SetPlayerChatBubble(Heist_Attackers[i], "** Niesie torbê wypchan¹ pieniêdzmi **", COLOR_DO, 60.0, 6500);
+	}
+	if(Heist_CheckEscape() == true)
+	{
+		Heist_PursuitCounter = 0;
+	}
+	else
+	{
+		Heist_PursuitCounter++;
+	}
+	if(Heist_PursuitCounter >= 3)
 	{
 		Heist_Win();
 	}

--- a/gamemodes/modules/napady/napady_timers.pwn
+++ b/gamemodes/modules/napady/napady_timers.pwn
@@ -124,7 +124,7 @@ public Heist_Escape()
 	{
 		Heist_Lost();
 	}
-	if(Heist_MapIconCounter == 2)
+	if(Heist_MapIconCounter == 2) //10s
 	{
 		Heist_UpdateMapIcon();
 		Heist_MapIconCounter = 0;
@@ -183,12 +183,14 @@ public Heist_LosePursuit()
 	{
 		Heist_Lost();
 	}
-	if(Heist_MapIconCounter == 5)
+	if(Heist_MapIconCounter == 3) //30s
 	{
 		Heist_UpdateMapIcon();
 		Heist_MapIconCounter = 0;
 	}
-
+	else
+		Heist_MapIconCounter++;
+	
 	new warning[48];
 	new time;
 	for(new i = 0; i < Heist_AttackersCount; i++)


### PR DESCRIPTION
+ Zwiększono blokadę na następny napad z 28 minut do 35 minut
+ Dodano trzeci etap ucieczki w którym liczy się bycie przez min. 30 sekund poza zasięgiem LSPD
- Jeżeli jakikolwiek oficer FBI lub LSPD na służbie będzie w pobliżu, naliczony czas do tych 30 sekund się zeruje
+ Zwiększono czas etapu kradzieży stacjonarnej z 180s do 240s
+ Zmniejszono czas etapu wolnej ucieczki z 490s do 350s