### PR TITLE
Poprawki do komendy /zapytaj i /tickets

### DIFF
--- a/gamemodes/commands/cmd/zapytaj.pwn
+++ b/gamemodes/commands/cmd/zapytaj.pwn
@@ -31,8 +31,8 @@
 YCMD:zapytaj(playerid, params[], help)
 {
     if(GetPVarInt(playerid, "active_ticket") != 0) return sendTipMessageEx(playerid, COLOR_GRAD2, "Twoje wczesniejsze zg³oszenie nadal jest aktywne. Poczekaj na odpowiedŸ!");
-    new desc[64];
-    if(sscanf(params, "s[64]", desc))
+    new desc[128];
+    if(sscanf(params, "s[128]", desc))
     {
         SendClientMessage(playerid, COLOR_YELLOW, "Potrzebujesz pomocy na temat gry IC? U¿yj zapytania do supportu!");
         SendClientMessage(playerid, COLOR_GRAD2, "Wpisz ogólny temat w nawiasach kwadratowych [TEMAT] oraz dalsz¹ tresc.");
@@ -46,16 +46,21 @@ YCMD:zapytaj(playerid, params[], help)
         SendClientMessage(playerid, COLOR_GRAD2, "Przyk³ad u¿ycia: {FFFFFF}/zapytaj [Pojazd] Gdzie kupiê swój pierwszy pojazd?");
         return 1;
     }
-    new sub[16], str[32];
+    new sub[17], str[87];
     strmid(sub, desc, pos+1, pos2);
     while(desc[pos2+1] == ' ')
     {
         strdel(desc, pos2, pos2+1);
     }
-    strmid(str, desc, pos2+1, strlen(desc), 32);
+    strmid(str, desc, pos2+1, strlen(desc));
     if(strlen(sub) < 2 || strlen(desc) < 10)
     {
         sendTipMessageEx(playerid, COLOR_GRAD2, "Poda³es za krótki opis lub temat.");
+        return 1;
+    }
+    if(strlen(sub) > 15 || strlen(str) > 85)
+    {
+        sendTipMessageEx(playerid, COLOR_GRAD2, "Maksymalna d³ugoœæ tematu to 15 znaków, a opisu - 85 znaków.");
         return 1;
     }
     new id;

--- a/gamemodes/dialogs/OnDialogResponse.pwn
+++ b/gamemodes/dialogs/OnDialogResponse.pwn
@@ -15443,12 +15443,16 @@ public OnDialogResponse(playerid, dialogid, response, listitem, inputtext[])
         new str[128];
         format(str, 64, "SUPPORT: %s oferuje Ci pomoc, skorzystaj z tego!", GetNick(playerid));
         SendClientMessage(pid, COLOR_YELLOW, str);
-        format(str, 128, "SUPPORT: Pomagasz teraz %s. Aby wróciæ do poprzedniej pozycji wpisz /ticketend", GetNick(pid));
+        format(str, 128, "SUPPORT: Pomagasz teraz %s. Aby wróciæ do poprzedniej pozycji wpisz /ticketend.", GetNick(pid));
         SendClientMessage(playerid, COLOR_YELLOW, str);
 		if(GetPVarInt(playerid, "dutyadmin") == 1)
 		{
 			iloscZapytaj[playerid] = iloscZapytaj[playerid]+1;
 		}
+
+		SendClientMessage(playerid, COLOR_YELLOW, "Pe³na treœæ pytania:");
+		format(str, sizeof(str), "%s", TICKET[id][suppDesc]);
+		SendClientMessage(playerid, COLOR_YELLOW, str);
 
         return 1;
     }

--- a/gamemodes/system/enum.pwn
+++ b/gamemodes/system/enum.pwn
@@ -58,7 +58,7 @@ enum eSupportData {
     bool:suppValid,
     suppCaller,
     suppSub[16],
-    suppDesc[32]
+    suppDesc[86]
 }
 //14.11
 enum eMySQLCar { //1+1+1+1+3+1+1+1+2+1+1+1+1+1+2+32+1+1+1 = 54 B

--- a/gamemodes/system/funkcje.pwn
+++ b/gamemodes/system/funkcje.pwn
@@ -11897,8 +11897,8 @@ Support_Add(caller, sub[], desc[])
     strdel(TICKET[id][suppSub], 0, 16);
     strins(TICKET[id][suppSub], sub, 0, 16);
 
-    strdel(TICKET[id][suppDesc], 0, 32);
-    strins(TICKET[id][suppDesc], desc, 0, 32);
+    strdel(TICKET[id][suppDesc], 0, 86);
+    strins(TICKET[id][suppDesc], desc, 0, 86);
     return id;
 }
 


### PR DESCRIPTION
Zwiększenie maksymalnej długości pytania na /zapytaj do 85 znaków. Weryfikowanie, czy gracz nie przekroczył długości pytania i wyświetlenie stosownego komunikatu, ponieważ dotychczas było to ucinane. W menu /tickets nadal wyświetla się skrócona wersja pytania (24 znaki), ale po wybraniu ticketu na czacie pojawia się jego pełna treść.