### PR TITLE
Dodanie administratorskiej komendy /sprawdzczasgry.

### DIFF
--- a/gamemodes/Mrucznik-RP.pwn
+++ b/gamemodes/Mrucznik-RP.pwn
@@ -1185,6 +1185,9 @@ public OnPlayerConnect(playerid)
         gSelectionItems[playerid][x] = PlayerText:INVALID_TEXT_DRAW;
 	}
 	gItemAt[playerid] = 0;
+
+	pSessionStart[playerid] = GetTickCount();
+
 	return 1;
 }
 public OnPlayerPause(playerid)

--- a/gamemodes/commands/cmd/ah.pwn
+++ b/gamemodes/commands/cmd/ah.pwn
@@ -69,7 +69,7 @@ YCMD:ah(playerid, params[], help)
 	{
 		SendClientMessage(playerid, COLOR_GRAD1, "*1* ADMIN *** /slap /kick /aj /bp /warn /block /ban /pblock /pban /pwarn /paj");
 		SendClientMessage(playerid, COLOR_GRAD1, "*1* ADMIN *** /freeze /unfreeze /mute /kill /dpa /mark /gotomark");
-		SendClientMessage(playerid, COLOR_GRAD1, "*1* ADMIN *** /setint /getint /setvw /getvw /wybieralka");
+		SendClientMessage(playerid, COLOR_GRAD1, "*1* ADMIN *** /setint /getint /setvw /getvw /wybieralka /sprawdzczasgry");
 		SendClientMessage(playerid, COLOR_GRAD1, "*1* ADMIN *** /mordinfo /gotomechy /podglad /gotocar /ip");
 		SendClientMessage(playerid, COLOR_GRAD1, "*1* ADMIN *** /check /pojazdygracza /sb /pokazcb /checktank");
 		SendClientMessage(playerid, COLOR_GRAD1, "*1* ADMIN *** /respawn /carjump /to /up /getcar /gethere");

--- a/gamemodes/commands/cmd/sprawdzczasgry.pwn
+++ b/gamemodes/commands/cmd/sprawdzczasgry.pwn
@@ -49,9 +49,6 @@ YCMD:sprawdzczasgry(playerid, params[], help)
     }
 
     new sessionLength = GetTickCount() - pSessionStart[giveplayerid];
-    printf("pSessionStart: %d", pSessionStart[giveplayerid]);
-    printf("Now: %d", GetTickCount());
-    printf("Session Length RAW: %d", sessionLength);
     sessionLength -= sessionLength % 1000; // zaokr¹glenie do pe³nych sekund
 
     new sLenUnderMinuteTicks = sessionLength % 60000;
@@ -60,9 +57,6 @@ YCMD:sprawdzczasgry(playerid, params[], help)
     new sessionSeconds = sLenUnderMinuteTicks / 1000;
     new sessionMinutes = (sLenUnderHourTicks - sLenUnderMinuteTicks) / 60000;
     new sessionHours = (sessionLength - sLenUnderHourTicks) / 3600000;
-
-    printf("sessionLength: %d | sLenUnderMinuteTicks: %d | sLenUnderHourTicks: %d", sessionLength, sLenUnderMinuteTicks, sLenUnderHourTicks);
-    printf("sessionSeconds: %d | minutes: %d | hours: %d", sessionSeconds, sessionMinutes, sessionHours);
 
 	new string[128];
     format(string, sizeof(string), "Czas gry gracza %s [ID %d]: Godzin - %d | Minut - %d | Sekund - %d", 

--- a/gamemodes/commands/cmd/sprawdzczasgry.pwn
+++ b/gamemodes/commands/cmd/sprawdzczasgry.pwn
@@ -1,0 +1,73 @@
+//-----------------------------------------------<< Komenda >>-----------------------------------------------//
+//------------------------------------------------[ sprawdzczasgry ]------------------------------------------------//
+//----------------------------------------------------*------------------------------------------------------//
+//----[                                                                                                 ]----//
+//----[         |||||             |||||                       ||||||||||       ||||||||||               ]----//
+//----[        ||| |||           ||| |||                      |||     ||||     |||     ||||             ]----//
+//----[       |||   |||         |||   |||                     |||       |||    |||       |||            ]----//
+//----[       ||     ||         ||     ||                     |||       |||    |||       |||            ]----//
+//----[      |||     |||       |||     |||                    |||     ||||     |||     ||||             ]----//
+//----[      ||       ||       ||       ||     __________     ||||||||||       ||||||||||               ]----//
+//----[     |||       |||     |||       |||                   |||    |||       |||                      ]----//
+//----[     ||         ||     ||         ||                   |||     ||       |||                      ]----//
+//----[    |||         |||   |||         |||                  |||     |||      |||                      ]----//
+//----[    ||           ||   ||           ||                  |||      ||      |||                      ]----//
+//----[   |||           ||| |||           |||                 |||      |||     |||                      ]----//
+//----[  |||             |||||             |||                |||       |||    |||                      ]----//
+//----[                                                                                                 ]----//
+//----------------------------------------------------*------------------------------------------------------//
+
+// Opis:
+/*
+	
+*/
+
+
+// Notatki skryptera:
+/*
+	
+*/
+
+YCMD:sprawdzczasgry(playerid, params[], help)
+{
+    if(PlayerInfo[playerid][pAdmin] == 0)
+	{
+        return 1;
+    }
+
+    new giveplayerid;
+    if( sscanf(params, "k<fix>", giveplayerid))
+    {
+        sendTipMessage(playerid, "U¿yj /sprawdzczasgry [id gracza]");
+        return 1;
+    }
+
+    if(!IsPlayerConnected(giveplayerid) || giveplayerid == INVALID_PLAYER_ID)
+    {
+        sendTipMessage(playerid, "Tego gracza nie ma na serwerze!");
+        return 1;         
+    }
+
+    new sessionLength = GetTickCount() - pSessionStart[giveplayerid];
+    printf("pSessionStart: %d", pSessionStart[giveplayerid]);
+    printf("Now: %d", GetTickCount());
+    printf("Session Length RAW: %d", sessionLength);
+    sessionLength -= sessionLength % 1000; // zaokr¹glenie do pe³nych sekund
+
+    new sLenUnderMinuteTicks = sessionLength % 60000;
+    new sLenUnderHourTicks = sessionLength % 3600000;
+
+    new sessionSeconds = sLenUnderMinuteTicks / 1000;
+    new sessionMinutes = (sLenUnderHourTicks - sLenUnderMinuteTicks) / 60000;
+    new sessionHours = (sessionLength - sLenUnderHourTicks) / 3600000;
+
+    printf("sessionLength: %d | sLenUnderMinuteTicks: %d | sLenUnderHourTicks: %d", sessionLength, sLenUnderMinuteTicks, sLenUnderHourTicks);
+    printf("sessionSeconds: %d | minutes: %d | hours: %d", sessionSeconds, sessionMinutes, sessionHours);
+
+	new string[128];
+    format(string, sizeof(string), "Czas gry gracza %s [ID %d]: Godzin - %d | Minut - %d | Sekund - %d", 
+        GetNick(giveplayerid), giveplayerid, sessionHours, sessionMinutes, sessionSeconds);
+    SendClientMessage(playerid, COLOR_WHITE, string);
+
+	return 1;
+}

--- a/gamemodes/commands/commands.pwn
+++ b/gamemodes/commands/commands.pwn
@@ -643,6 +643,7 @@
 #include "cmd/inwigilacja.pwn"
 #include "cmd/togro.pwn"
 #include "cmd/paralizator.pwn"
+#include "cmd/sprawdzczasgry.pwn"
 InitCommands()
 {
 	Aliases();
@@ -1497,6 +1498,9 @@ static Aliases()
 	//paralizator
 	Command_AddAltNamed("paralizator", "taser");
 	Command_AddAltNamed("paralizator", "tazer");
+
+	//sprawdzczasgry
+	Command_AddAltNamed("sprawdzczasgry", "getplaytime");
 
 	foreach (new command : Command())
 	{

--- a/gamemodes/system/zmienne.pwn
+++ b/gamemodes/system/zmienne.pwn
@@ -735,6 +735,7 @@ new MoneyMessage[MAX_PLAYERS];
 new Condom[MAX_PLAYERS];
 new SexOffer[MAX_PLAYERS];
 new SexPrice[MAX_PLAYERS];
+new pSessionStart[MAX_PLAYERS] = {0, ...}; // czas wbicia gracza na serwer
 //BW
 new PlayerRequestMedic[MAX_PLAYERS];
 
@@ -1483,6 +1484,8 @@ ZerujZmienne(playerid)
 	areVehicleDescTurnedOn[playerid] = true;
 
 	VECTOR_clear(VMembersOrg[playerid]);
+
+	pSessionStart[playerid] = 0;
 	
 	return 1;
 }


### PR DESCRIPTION
Komenda służy do sprawdzenia ile gracz siedzi na serwerze w obecnej sesji - na prośbę adminów.