### PR TITLE
Zmiany w żużlu

### DIFF
--- a/gamemodes/Mrucznik-RP.pwn
+++ b/gamemodes/Mrucznik-RP.pwn
@@ -4470,42 +4470,39 @@ public OnPlayerEnterCheckpoint(playerid)
 			    new sendername[MAX_PLAYER_NAME];
 			    GetPlayerName(playerid, sendername, sizeof(sendername));
 				format(string, sizeof(string), "Wygra³ %s - ukoñczy³ wyœcig zajmuj¹c 1 miejsce !!!.", sendername);
-				ProxDetectorW(500, -1106.9854, -966.4719, 129.1807, COLOR_WHITE, string);
+				ProxDetectorW(300, -1106.9854, -966.4719, 129.1807, COLOR_WHITE, string);
 				DisablePlayerCheckpoint(playerid);
 		        DisablePlayerCheckpoint(playerid);
 		        zawodnik[playerid] = 0;
 		        okrazenia[playerid] = 0;
 	   			okregi[playerid] = 0;
 				iloscwygranych ++;
-				SetTimerEx("TablicaWynikow",1000,0,"d",playerid);
 			}
 			else if(iloscwygranych == 1)
 			{
 			    new sendername[MAX_PLAYER_NAME];
 			    GetPlayerName(playerid, sendername, sizeof(sendername));
 				format(string, sizeof(string), "%s ukoñczy³ wyœcig zajmuj¹c 2 miejsce !!.", sendername);
-				ProxDetectorW(500, -1106.9854, -966.4719, 129.1807, COLOR_WHITE, string);
+				ProxDetectorW(300, -1106.9854, -966.4719, 129.1807, COLOR_WHITE, string);
 				DisablePlayerCheckpoint(playerid);
 		        DisablePlayerCheckpoint(playerid);
 		        zawodnik[playerid] = 0;
 		        okrazenia[playerid] = 0;
 	   			okregi[playerid] = 0;
 				iloscwygranych ++;
-				SetTimerEx("TablicaWynikow",1000,0,"d",playerid);
 			}
 			else if(iloscwygranych == 2)
 			{
 			    new sendername[MAX_PLAYER_NAME];
 			    GetPlayerName(playerid, sendername, sizeof(sendername));
 				format(string, sizeof(string), "%s ukoñczy³ wyœcig zajmuj¹c 3 miejsce !.", sendername);
-				ProxDetectorW(500, -1106.9854, -966.4719, 129.1807, COLOR_WHITE, string);
+				ProxDetectorW(300, -1106.9854, -966.4719, 129.1807, COLOR_WHITE, string);
 				DisablePlayerCheckpoint(playerid);
 		        DisablePlayerCheckpoint(playerid);
 		        zawodnik[playerid] = 0;
 		        okrazenia[playerid] = 0;
 	   			okregi[playerid] = 0;
 				iloscwygranych ++;
-				SetTimerEx("TablicaWynikow",1000,0,"d",playerid);
 			}
 			else
 			{
@@ -4513,13 +4510,12 @@ public OnPlayerEnterCheckpoint(playerid)
 			    new sendername[MAX_PLAYER_NAME];
 			    GetPlayerName(playerid, sendername, sizeof(sendername));
 				format(string, sizeof(string), "%s ukoñczy³ wyœcig zajmuj¹c %d miejsce !.", sendername, iloscwygranych);
-				ProxDetectorW(500, -1106.9854, -966.4719, 129.1807, COLOR_WHITE, string);
+				ProxDetectorW(300, -1106.9854, -966.4719, 129.1807, COLOR_WHITE, string);
 				DisablePlayerCheckpoint(playerid);
 		        DisablePlayerCheckpoint(playerid);
 		        zawodnik[playerid] = 0;
 		        okrazenia[playerid] = 0;
 	   			okregi[playerid] = 0;
-	   			SetTimerEx("TablicaWynikow",1000,0,"d",playerid);
 			}
 	   	}
   		else if(okrazenia[playerid] == 0)

--- a/gamemodes/commands/cmd/brama.pwn
+++ b/gamemodes/commands/cmd/brama.pwn
@@ -865,7 +865,7 @@ YCMD:brama(playerid, params[], help)
 		}*/ 
 		//==============================[KONIEC]====================================================
 		//..
-		if(PlayerInfo[playerid][pMember] == 9 || PlayerInfo[playerid][pLider] == 9  || strcmp(GetNick(playerid),"Gonzalo_DiNorscio", false) == 0 || PlayerInfo[playerid][pAdmin] > 1/*PlayerInfo[playerid][pJob] == 14*/)
+		if(PlayerInfo[playerid][pMember] == 9 || PlayerInfo[playerid][pLider] == 9  || strcmp(GetNick(playerid),"Gonzalo_DiNorscio", false) == 0 || PlayerInfo[playerid][pAdmin] >= 1)
 		{
 			if(IsPlayerInRangeOfPoint(playerid, 10.0, -1113.25769043,-1008.68634033,128.90229797))
 			{

--- a/gamemodes/commands/cmd/dajkm.pwn
+++ b/gamemodes/commands/cmd/dajkm.pwn
@@ -59,8 +59,8 @@ YCMD:dajkm(playerid, params[], help)
 						format(string, sizeof(string), "   Gracz %s jest teraz komentator ¿u¿lowym.", giveplayer);
 						SendClientMessage(playerid, COLOR_LIGHTBLUE, string);
 						komentator[para1] = 1;
-						format(string, sizeof(string), "Komentator: Witam! Tu %s ! Bêdê komentowa³ ten wyœcig.", giveplayer);
-						ProxDetectorW(500, -1106.9854, -966.4719, 129.1807, COLOR_WHITE, string);
+						format(string, sizeof(string), "Komentator: Witam! Tu %s! Bêdê komentowa³ ten wyœcig.", giveplayer);
+						ProxDetectorW(300, -1106.9854, -966.4719, 129.1807, COLOR_WHITE, string);
 					}
 					else
 					{

--- a/gamemodes/commands/cmd/kmwyniki.pwn
+++ b/gamemodes/commands/cmd/kmwyniki.pwn
@@ -1,5 +1,5 @@
 //-----------------------------------------------<< Komenda >>-----------------------------------------------//
-//-----------------------------------------------[ zuzel_stop ]----------------------------------------------//
+//------------------------------------------------[ kmwyniki ]-----------------------------------------------//
 //----------------------------------------------------*------------------------------------------------------//
 //----[                                                                                                 ]----//
 //----[         |||||             |||||                       ||||||||||       ||||||||||               ]----//
@@ -28,16 +28,39 @@
 	
 */
 
-YCMD:zuzel_stop(playerid, params[], help)
+YCMD:kmwyniki(playerid, params[], help)
 {
-    if(IsPlayerConnected(playerid))
+	new string[128];
+    new kmName[MAX_PLAYER_NAME];
+    new pName[MAX_PLAYER_NAME];
+
+    if(!IsPlayerConnected(playerid))
     {
-		if (PlayerInfo[playerid][pAdmin] >= 1 || PlayerInfo[playerid][pMember] == 9 && PlayerInfo[playerid][pRank] >= 2 || strcmp(GetNick(playerid),"Gonzalo_DiNorscio", false) == 0)
-		{
-		    wyscigz = 0;
-		    iloscwygranych = 0;
-			ProxDetectorW(300, -1106.9854, -966.4719, 129.1807, COLOR_WHITE, "Wyœcig ¿u¿lowy zakoñczony!");
-		}
-	}
+        return 1;
+    }
+
+    if(!komentator[playerid])
+    {
+        sendErrorMessage(playerid, "Nie jesteœ komentatorem!");
+        return 1;
+    }
+
+    GetPlayerName(playerid, kmName, sizeof(kmName));
+
+    format(string, sizeof(string), "Komentator %s: Podajê wyniki!", kmName);
+    ProxDetectorW(300, -1106.9854, -966.4719, 129.1807, COLOR_P@, string);
+
+    foreach(new p : Player)
+    {
+        if(zawodnik[p]) // je¿eli gracz jest zawodnikiem
+        {
+            GetPlayerName(playerid, pName);
+            strreplace(pName, "_", " ", true);
+
+            format(string, sizeof(string), "Komentator %s: Zawodnik %s - %d okr¹¿eñ.", kmName, pName, okregi[p]);
+            ProxDetectorW(300, -1106.9854, -966.4719, 129.1807, COLOR_P@, string);
+        }
+    }
+	
 	return 1;
 }

--- a/gamemodes/commands/cmd/komentuj.pwn
+++ b/gamemodes/commands/cmd/komentuj.pwn
@@ -44,7 +44,7 @@ YCMD:komentuj(playerid, params[], help)
 				return 1;
 			}
 			format(string, sizeof(string), "Komentator %s: %s", sendername, params);
-			ProxDetectorW(500, -1106.9854, -966.4719, 129.1807, COLOR_P@, string);
+			ProxDetectorW(300, -1106.9854, -966.4719, 129.1807, COLOR_P@, string);
         }
         else
         {

--- a/gamemodes/commands/cmd/zawodnik.pwn
+++ b/gamemodes/commands/cmd/zawodnik.pwn
@@ -59,8 +59,8 @@ YCMD:zawodnik(playerid, params[], help)
 						format(string, sizeof(string), "   Gracz %s jest teraz zawodnikiem ¿u¿lowym.", giveplayer);
 						SendClientMessage(playerid, COLOR_LIGHTBLUE, string);
 						zawodnik[para1] = 1;
-						format(string, sizeof(string), "Mamy nowego zawodnika ¿u¿lowego - %s !!.", giveplayer);
-						ProxDetectorW(500, -1106.9854, -966.4719, 129.1807, COLOR_WHITE, string);
+						format(string, sizeof(string), "Mamy nowego zawodnika ¿u¿lowego - %s!!.", giveplayer);
+						ProxDetectorW(300, -1106.9854, -966.4719, 129.1807, COLOR_WHITE, string);
 					}
 					else
 					{
@@ -72,7 +72,7 @@ YCMD:zawodnik(playerid, params[], help)
 						SendClientMessage(playerid, COLOR_LIGHTBLUE, string);
 						zawodnik[para1] = 0;
 						format(string, sizeof(string), "Zawodnik ¿u¿lowy %s odpad³ podczas wyœcigu.", giveplayer);
-						ProxDetectorW(500, -1106.9854, -966.4719, 129.1807, COLOR_WHITE, string);
+						ProxDetectorW(300, -1106.9854, -966.4719, 129.1807, COLOR_WHITE, string);
 					}
 				}
 			}

--- a/gamemodes/commands/cmd/zuzel.pwn
+++ b/gamemodes/commands/cmd/zuzel.pwn
@@ -32,7 +32,7 @@ YCMD:zuzel(playerid, params[], help)
 {
     if(GUIExit[playerid] == 0)
     {
-    	ShowPlayerDialogEx(playerid, 1234, DIALOG_STYLE_LIST, "Komendy øuølowe", "/zawodnik\t\tAdmin\n/zawodnicy\n/dajkm\t\t\tAdmin\n/wyniki\n/km\t\t\tKomentator\n/zuzel_start\t\tAdmin", "Wyjdü", "");
+    	ShowPlayerDialogEx(playerid, 1234, DIALOG_STYLE_LIST, "Komendy øuølowe", "/zawodnik\t\tAdmin\n/zawodnicy\n/dajkm\t\t\tAdmin\n/wyniki\n/km\t\t\tKomentator\n/kmwyniki\t\t\tKomentator\n/zuzel_start\t\tAdmin", "Wyjdü", "");
 	}
 	return 1;
 }

--- a/gamemodes/commands/cmd/zuzel_start.pwn
+++ b/gamemodes/commands/cmd/zuzel_start.pwn
@@ -38,8 +38,8 @@ YCMD:zuzel_start(playerid, params[], help)
 		    {
 		    	StartZuzling();
 		    	wyscigz = 1;
-				ProxDetectorW(500, -1106.9854, -966.4719, 129.1807, COLOR_WHITE, "Wyœcig ¿u¿lowy rozpoczêty!");
-				SetTimerEx("TablicaWynikow",30000,0,"d",playerid);
+				ProxDetectorW(300, -1106.9854, -966.4719, 129.1807, COLOR_WHITE, "Wyœcig ¿u¿lowy rozpoczêty!");
+				
 				SendClientMessage(playerid, COLOR_GRAD2, "Zuzel start");
 			}
 			else

--- a/gamemodes/commands/commands.pwn
+++ b/gamemodes/commands/commands.pwn
@@ -215,6 +215,7 @@
 #include "cmd/kickall.pwn"
 #include "cmd/kill.pwn"
 #include "cmd/killall.pwn"
+#include "cmd/kmwyniki.pwn"
 #include "cmd/kod.pwn"
 #include "cmd/kogut.pwn"
 #include "cmd/kolejka.pwn"

--- a/gamemodes/system/funkcje.pwn
+++ b/gamemodes/system/funkcje.pwn
@@ -1538,37 +1538,6 @@ DisablePlayerCheckpoint(playerid);
 return 1;
 }
 
-public TablicaWynikow(playerid)
-{
-	foreach(new i : Player)
-	{
-		if(IsPlayerInRangeOfPoint(i, 500, -1106.9854, -966.4719, 129.1807))
-		{
-			SendClientMessage(i, COLOR_LIGHTGREEN, "Tabela wyników:");
-            foreach(new di : Player)
-			{
-			    if(zawodnik[di] == 1)
-			    {
-			        if(okregi[di] >= 1)
-			        {
-			            new iplayer[MAX_PLAYER_NAME];
-			            new string[256];
-				        GetPlayerName(di, iplayer, sizeof(iplayer));
-				        format(string, sizeof(string), "%s - %d okr¹¿eñ", iplayer, okregi[di]);
-						SendClientMessage(i, COLOR_WHITE, string);
-					}
-			    }
-			}
-		}
-	}
-	if(wyscigz == 1)
-	{
-		SetTimerEx("TablicaWynikow",30000,0,"d",playerid);
-	}
-//}
-//return 1;
-}
-
 //Osobno
 public AutodbzesRH(playerid)
 {


### PR DESCRIPTION
Zmiany w żużlu:
- udostępnienie /brama na żużlu od 1 @lvl;
- zlikwidowanie spamu tabelą wyników, zamiast tego komenda /kmwyniki dla komentatora żużlowego;
- zmniejszenie zasięgu żużlowych komunikatów z 500 do 300 jednostek.

Na prośbę adminów.