### PR TITLE
Poprawki do /caluj

### DIFF
--- a/gamemodes/Mrucznik-RP.pwn
+++ b/gamemodes/Mrucznik-RP.pwn
@@ -1288,8 +1288,6 @@ public OnPlayerDisconnect(playerid, reason)
 	OfferPrice[playerid] = 0;
 	LawyerOffer[playerid] = 0;
 	ClearVariableDisconnect(playerid); 
-	//caluj
-	kissPlayerOffer[playerid] = 0;
 	//komunikaty frakcyjne
 	komunikatMinutyZerowanie[playerid]=0;
 

--- a/gamemodes/commands/cmd/caluj.pwn
+++ b/gamemodes/commands/cmd/caluj.pwn
@@ -30,55 +30,85 @@
 
 YCMD:caluj(playerid, params[], help)
 {
-	new string[128];
-    if(IsPlayerConnected(playerid))
-    {
-		new playa;
-		if( sscanf(params, "k<fix>", playa))
-		{
-			sendTipMessage(playerid, "U¿yj /caluj [ID gracza]");
-			return 1;
-		}
-		if(playa == playerid)
-		{
-			sendErrorMessage(playerid, "Nie mo¿esz poca³owaæ samego siebie!"); 
-			return 1;
-		}
-		if(GetPlayerAdminDutyStatus(playa) == 1)
-		{
-			sendErrorMessage(playerid, "Nie mo¿esz ca³owaæ administratora!"); 
-			return 1;
-		}
-		if(GetPlayerAdminDutyStatus(playerid) == 1)
-		{
-			sendErrorMessage(playerid, "Nie mo¿esz ca³owaæ siê bêd¹c na s³u¿bie @"); 
-			return 1;
-		}
-		if(dialAccess[playerid] == 1)
-		{
-			sendErrorMessage(playerid, "Musisz odczekaæ 15 sekund przed ponownym poca³unkiem!"); 
-			return 1;
-		}
-		if (ProxDetectorS(5.0, playerid, playa))
-		{
-		    if(IsPlayerConnected(playa))
-		    {
-		        if(playa != INVALID_PLAYER_ID)
-		        {
-					dialAccess[playa] = 0; 
-					format(string, sizeof(string), "%s chce siê z tob¹ poca³owaæ - jeœli go kochasz kliknij ''Ca³uj''!", GetNick(playerid));
-  					ShowPlayerDialogEx(playa, 1092, DIALOG_STYLE_MSGBOX, "Mrucznik Role Play - poca³unek", string, "Ca³uj", "Odrzuæ", false);
-					ShowPlayerInfoDialog(playerid, "Mrucznik Role-Play", "Zaoferowa³eœ poca³unek - oczekuj na reakcje!", true);
-					format(string, sizeof(string), "Zaoferowa³eœ poca³unek %s - oczekuj na reakcje!", GetNick(playa));
-					sendTipMessage(playerid, string);
-					kissPlayerOffer[playa] = playerid;
-				}
-			}
-		}
-		else
-		{
-			sendErrorMessage(playerid, "Jesteœ za daleko !");
-		}
+	if(!IsPlayerConnected(playerid))
+	{
+		return 1;
 	}
+
+	new string[128];
+	new playa;
+	
+	if( sscanf(params, "k<fix>", playa))
+	{
+		sendTipMessage(playerid, "U¿yj /caluj [ID gracza]");
+		return 1;
+	}
+	if(playa == playerid)
+	{
+		sendErrorMessage(playerid, "Nie mo¿esz poca³owaæ samego siebie!"); 
+		return 1;
+	}
+	if(GetPlayerAdminDutyStatus(playa) == 1)
+	{
+		sendErrorMessage(playerid, "Nie mo¿esz ca³owaæ administratora!"); 
+		return 1;
+	}
+	if(GetPlayerAdminDutyStatus(playerid) == 1)
+	{
+		sendErrorMessage(playerid, "Nie mo¿esz ca³owaæ siê bêd¹c na s³u¿bie @"); 
+		return 1;
+	}
+	if(dialAccess[playerid] == 1)
+	{
+		sendErrorMessage(playerid, "Musisz odczekaæ 15 sekund przed ponownym poca³unkiem!"); 
+		return 1;
+	}
+	if (!ProxDetectorS(5.0, playerid, playa))
+	{
+		sendErrorMessage(playerid, "Jesteœ za daleko !");
+		return 1;
+	}
+	if(playa == INVALID_PLAYER_ID || !IsPlayerConnected(playa))
+	{
+		sendErrorMessage(playerid, "Takiego gracza nie ma na serwerze!");
+		return 1;
+	}
+	if(kissPlayerOffer[playa] == playerid)
+	{
+		sendErrorMessage(playerid, "Ju¿ zaoferowa³eœ/³aœ poca³unek temu graczowi, poczekaj na reakcjê!");
+		return 1;
+	}
+
+	if(kissPlayerOffer[playerid] == playa)
+	{
+			format(string, sizeof(string),"* %s kocha %s wiêc ca³uj¹ siê.", GetNick(playerid), GetNick(playa));
+			ProxDetector(20.0, playerid, string, COLOR_PURPLE,COLOR_PURPLE,COLOR_PURPLE,COLOR_PURPLE,COLOR_PURPLE);
+			format(string, sizeof(string), "%s mówi: Kocham ciê.", GetNick(playa));
+			ProxDetector(20.0, playerid, string, COLOR_WHITE,COLOR_WHITE,COLOR_WHITE,COLOR_WHITE,COLOR_WHITE);
+			format(string, sizeof(string), "%s mówi: Ja ciebie te¿.", GetNick(playerid));
+			ProxDetector(20.0, playerid, string, COLOR_WHITE,COLOR_WHITE,COLOR_WHITE,COLOR_WHITE,COLOR_WHITE);
+
+			ApplyAnimation(playerid, "KISSING", "Playa_Kiss_02", 4.0, 0, 0, 0, 0, 0);
+			ApplyAnimation(playa, "KISSING", "Playa_Kiss_01", 4.0, 0, 0, 0, 0, 0);
+			
+			kissPlayerOffer[playerid] = INVALID_PLAYER_ID;
+	}
+	else if(kissPlayerOffer[playa] == INVALID_PLAYER_ID)
+	{
+		dialAccess[playa] = 0; // limit czasowy - jedna propozycja poca³unku na 15 sekund
+
+		format(string, sizeof(string), "%s chce siê z tob¹ poca³owaæ - jeœli go kochasz odwzajemnij >> /caluj <<, masz na to 10 sekund!", GetNick(playerid));
+		SendClientMessage(playa, COLOR_LIGHTBLUE, string);
+		sendTipMessage(playerid, "Zaoferowa³eœ poca³unek - oczekuj na reakcjê!");
+
+		kissPlayerOffer[playa] = playerid;
+		SetTimerEx("KissRejectTimer", 10000, false, "dd", playerid, playa);
+	}
+	else
+	{
+		format(string, sizeof(string), "Poczekaj, ktoœ inny próbuje ju¿ poca³owaæ %s!", GetNick(playa));
+		sendErrorMessage(playerid, string);
+	}
+
 	return 1;
 }

--- a/gamemodes/dialogs/OnDialogResponse.pwn
+++ b/gamemodes/dialogs/OnDialogResponse.pwn
@@ -16128,42 +16128,6 @@ public OnDialogResponse(playerid, dialogid, response, listitem, inputtext[])
         }
 	
 	}
-	else if(dialogid == 1092)//Ca³uj - komenda - potwierdzenie
-	{
-		if(response)
-		{
-			if(ProxDetectorS(5.5, playerid, kissPlayerOffer[playerid]))
-			{
-				new string[128];
-				format(string, sizeof(string),"* %s kocha %s wiêc ca³uj¹ siê.", GetNick(playerid), GetNick(kissPlayerOffer[playerid]));
-				ProxDetector(20.0, playerid, string, COLOR_PURPLE,COLOR_PURPLE,COLOR_PURPLE,COLOR_PURPLE,COLOR_PURPLE);
-				format(string, sizeof(string), "%s mówi: Kocham ciê.", GetNick(kissPlayerOffer[playerid]));
-				ProxDetector(20.0, playerid, string, COLOR_WHITE,COLOR_WHITE,COLOR_WHITE,COLOR_WHITE,COLOR_WHITE);
-				format(string, sizeof(string), "%s mówi: Ja ciebie te¿.", GetNick(playerid));
-				ProxDetector(20.0, playerid, string, COLOR_WHITE,COLOR_WHITE,COLOR_WHITE,COLOR_WHITE,COLOR_WHITE);
-				ApplyAnimation(playerid, "KISSING", "Playa_Kiss_02", 4.0, 0, 0, 0, 0, 0);
-				ApplyAnimation(kissPlayerOffer[playerid], "KISSING", "Playa_Kiss_01", 4.0, 0, 0, 0, 0, 0);
-				
-				//zerowanie zmiennych:
-				kissPlayerOffer[playerid] = 0;
-			}
-			else
-			{
-				sendTipMessage(playerid, "Mi³oœæ Ci uciek³a!"); 
-				return 1;
-			}
-		}
-		if(!response)
-		{
-			
-			new string[128];
-			format(string, sizeof(string), "* %s spojrza³(a) na %s i stwierdzi³(a), ¿e nie chce siê ca³owaæ!", GetNick(playerid), GetNick(kissPlayerOffer[playerid]));
-			ProxDetector(20.0, playerid, string, COLOR_PURPLE,COLOR_PURPLE,COLOR_PURPLE,COLOR_PURPLE,COLOR_PURPLE);
-		
-			return 1;
-		}
-	
-	}
     else if(dialogid == 7079)
 	{
 		if(response)

--- a/gamemodes/system/timery.pwn
+++ b/gamemodes/system/timery.pwn
@@ -3534,4 +3534,28 @@ public DamagedHP(playerid)
 	return 1;
 }
 
+forward KissRejectTimer(kissingid, kissedid);
+public KissRejectTimer(kissingid, kissedid)
+{
+	new string[128];
+
+	if(kissPlayerOffer[kissedid] == kissingid)
+	{
+		if (ProxDetectorS(10.0, kissedid, kissingid))
+		{
+			format(string, sizeof(string), "* %s spojrza³(a) na %s i stwierdzi³(a), ¿e nie chce siê ca³owaæ!", GetNick(kissedid), GetNick(kissingid));
+			ProxDetector(20.0, kissedid, string, COLOR_PURPLE,COLOR_PURPLE,COLOR_PURPLE,COLOR_PURPLE,COLOR_PURPLE);
+		}
+		else
+		{
+			format(string, sizeof(string), "* mimo prób %s, nie mog³o dojœæ do poca³unku miêdzy nim/ni¹ a %s, poniewa¿ s¹ od siebie za daleko!", GetNick(kissingid), GetNick(kissedid));
+			ProxDetector(20.0, kissingid, string, COLOR_DO,COLOR_DO,COLOR_DO,COLOR_DO,COLOR_DO);
+		}
+
+		kissPlayerOffer[kissedid] = INVALID_PLAYER_ID;
+	}
+
+	return 1;
+}
+
 //EOF

--- a/gamemodes/system/zmienne.pwn
+++ b/gamemodes/system/zmienne.pwn
@@ -78,7 +78,7 @@ new OfferPrice[MAX_PLAYERS];
 
 new vinylStatus; 
 //Caluj - oferta
-new kissPlayerOffer[MAX_PLAYERS];
+new kissPlayerOffer[MAX_PLAYERS] = {INVALID_PLAYER_ID, ...};
 //ALARM DMV:
 new DMV_ALARM = 0;
 new bramaAlarmu[4];
@@ -1483,6 +1483,9 @@ ZerujZmienne(playerid)
 	areVehicleDescTurnedOn[playerid] = true;
 
 	VECTOR_clear(VMembersOrg[playerid]);
+
+	//caluj
+	kissPlayerOffer[playerid] = INVALID_PLAYER_ID;
 	
 	return 1;
 }


### PR DESCRIPTION
Zmiana z okienek na komendy. Komenda /caluj była wykorzystywana złośliwie np. podczas pościgów i strzelanin, by kogoś zaskoczyć i zatrzymać okienkiem.