### PR TITLE
Komenda /ip5

### DIFF
--- a/gamemodes/commands/cmd/ah.pwn
+++ b/gamemodes/commands/cmd/ah.pwn
@@ -70,7 +70,7 @@ YCMD:ah(playerid, params[], help)
 		SendClientMessage(playerid, COLOR_GRAD1, "*1* ADMIN *** /slap /kick /aj /bp /warn /block /ban /pblock /pban /pwarn /paj");
 		SendClientMessage(playerid, COLOR_GRAD1, "*1* ADMIN *** /freeze /unfreeze /mute /kill /dpa /mark /gotomark");
 		SendClientMessage(playerid, COLOR_GRAD1, "*1* ADMIN *** /setint /getint /setvw /getvw /wybieralka");
-		SendClientMessage(playerid, COLOR_GRAD1, "*1* ADMIN *** /mordinfo /gotomechy /podglad /gotocar /ip");
+		SendClientMessage(playerid, COLOR_GRAD1, "*1* ADMIN *** /mordinfo /gotomechy /podglad /gotocar /ip /ip5");
 		SendClientMessage(playerid, COLOR_GRAD1, "*1* ADMIN *** /check /pojazdygracza /sb /pokazcb /checktank");
 		SendClientMessage(playerid, COLOR_GRAD1, "*1* ADMIN *** /respawn /carjump /to /up /getcar /gethere");
 		SendClientMessage(playerid, COLOR_GRAD1, "*1* ADMIN *** /cnn /cc /spec /unblock /unwarn /forum /pogodaall");

--- a/gamemodes/modules/listaip/commands/ip5/command.json
+++ b/gamemodes/modules/listaip/commands/ip5/command.json
@@ -1,0 +1,20 @@
+{
+    "name": "ip5",
+    "description": "Wyœwietlanie 5 ostatnich adresów IP, na których gra³ gracz pod danym nickiem.",
+    "permissions": [],
+    "author": "NikodemBanan",
+    "aliases": [],
+    "parameters": [
+        {
+            "type": "player",
+            "name": "giveplayer",
+            "description": "Nick/ID"
+        },
+        {
+            "type": "bool",
+            "name": "isOffline",
+            "description": "Czy gracz offline"
+        }
+    ],
+    "date": "20.03.2024"
+}

--- a/gamemodes/modules/listaip/commands/ip5/ip5.pwn
+++ b/gamemodes/modules/listaip/commands/ip5/ip5.pwn
@@ -1,0 +1,96 @@
+//------------------------------------------<< Generated source >>-------------------------------------------//
+//                                                ip5                                                //
+//----------------------------------------------------*------------------------------------------------------//
+//----[                                                                                                 ]----//
+//----[         |||||             |||||                       ||||||||||       ||||||||||               ]----//
+//----[        ||| |||           ||| |||                      |||     ||||     |||     ||||             ]----//
+//----[       |||   |||         |||   |||                     |||       |||    |||       |||            ]----//
+//----[       ||     ||         ||     ||                     |||       |||    |||       |||            ]----//
+//----[      |||     |||       |||     |||                    |||     ||||     |||     ||||             ]----//
+//----[      ||       ||       ||       ||     __________     ||||||||||       ||||||||||               ]----//
+//----[     |||       |||     |||       |||                   |||    |||       |||                      ]----//
+//----[     ||         ||     ||         ||                   |||     ||       |||                      ]----//
+//----[    |||         |||   |||         |||                  |||     |||      |||                      ]----//
+//----[    ||           ||   ||           ||                  |||      ||      |||                      ]----//
+//----[   |||           ||| |||           |||                 |||      |||     |||                      ]----//
+//----[  |||             |||||             |||                |||       |||    |||                      ]----//
+//----[                                                                                                 ]----//
+//----------------------------------------------------*------------------------------------------------------//
+// Kod wygenerowany automatycznie narzêdziem Mrucznik CTL
+
+// ================= UWAGA! =================
+//
+// WSZELKIE ZMIANY WPROWADZONE DO TEGO PLIKU
+// ZOSTAN¥ NADPISANE PO WYWO£ANIU KOMENDY
+// > mrucznikctl build
+//
+// ================= UWAGA! =================
+
+
+//-------<[ include ]>-------
+#include "ip5_impl.pwn"
+
+//-------<[ initialize ]>-------
+command_ip5()
+{
+    
+
+    //aliases
+    
+
+    //permissions
+    
+
+    //prefix
+    
+}
+
+//-------<[ command ]>-------
+YCMD:ip5(playerid, params[], help)
+{
+    if (help)
+    {
+        sendTipMessage(playerid, "Wyœwietlanie 5 ostatnich adresów IP, na których gra³ gracz pod danym nickiem.");
+        return 1;
+    }
+    //fetching params
+
+    if(isnull(params))
+    {
+        sendTipMessage(playerid, "U¿yj /ip5 [Nick/ID] ");
+        return 1;
+    }
+
+    new offline = false;
+    new giveplayer[MAX_PLAYER_NAME];
+    if(sscanf(params, "r", giveplayer) || !IsPlayerConnected(giveplayer[0]))
+    {
+        new formatString[8];
+        format(formatString, sizeof(formatString), "s[%d]", MAX_PLAYER_NAME);
+        sscanf(params, formatString, giveplayer);
+        offline = true;
+    }
+    //command body
+    return command_ip5_Impl(playerid, giveplayer, offline);
+}
+
+YCMD:ip5addfake(playerid, params[], help)
+{
+    if(isnull(params))
+    {
+        sendTipMessage(playerid, "U¿yj /ip5addfake [Nick/ID]");
+        return 1;
+    }
+
+    new ipString[32];
+    new string[128];
+    format(ipString, sizeof(ipString), "%d.%d.%d.%d", random(256), random(256), random(256), random(256));
+    IP5AddIPToList(params, ipString);
+    format(string, sizeof(string), "Dodano adres %s pod nick %s.", ipString, params);
+    SendClientMessage(playerid, COLOR_LIGHTRED, string);
+
+    return 1;
+}
+
+/*
+*/

--- a/gamemodes/modules/listaip/commands/ip5/ip5.pwn
+++ b/gamemodes/modules/listaip/commands/ip5/ip5.pwn
@@ -74,23 +74,5 @@ YCMD:ip5(playerid, params[], help)
     return command_ip5_Impl(playerid, giveplayer, offline);
 }
 
-YCMD:ip5addfake(playerid, params[], help)
-{
-    if(isnull(params))
-    {
-        sendTipMessage(playerid, "U¿yj /ip5addfake [Nick/ID]");
-        return 1;
-    }
-
-    new ipString[32];
-    new string[128];
-    format(ipString, sizeof(ipString), "%d.%d.%d.%d", random(256), random(256), random(256), random(256));
-    IP5AddIPToList(params, ipString);
-    format(string, sizeof(string), "Dodano adres %s pod nick %s.", ipString, params);
-    SendClientMessage(playerid, COLOR_LIGHTRED, string);
-
-    return 1;
-}
-
 /*
 */

--- a/gamemodes/modules/listaip/commands/ip5/ip5_impl.pwn
+++ b/gamemodes/modules/listaip/commands/ip5/ip5_impl.pwn
@@ -1,5 +1,5 @@
-//-----------------------------------------------<< Komenda >>-----------------------------------------------//
-//---------------------------------------------------[ ip ]--------------------------------------------------//
+//-----------------------------------------------<< Source >>------------------------------------------------//
+//                                                ip5                                                //
 //----------------------------------------------------*------------------------------------------------------//
 //----[                                                                                                 ]----//
 //----[         |||||             |||||                       ||||||||||       ||||||||||               ]----//
@@ -16,48 +16,44 @@
 //----[  |||             |||||             |||                |||       |||    |||                      ]----//
 //----[                                                                                                 ]----//
 //----------------------------------------------------*------------------------------------------------------//
-
-// Opis:
-/*
-
- */
+// Autor: NikodemBanan
+// Data utworzenia: 20.03.2024
 
 
-// Notatki skryptera:
-/*
+//
 
- */
-
-YCMD:ip(playerid, params[], help)
+//------------------<[ Implementacja: ]>-------------------
+command_ip5_Impl(playerid, giveplayer[], offline)
 {
-    new string[128];
-    new giveplayer[MAX_PLAYER_NAME];
+    new giveplayername[MAX_PLAYER_NAME];
 
-    if (PlayerInfo[playerid][pAdmin] >= 1)
-    {
-        new giveplayerid;
-        if( sscanf(params, "k<fix>", giveplayerid))
-        {
-            sendTipMessage(playerid, "U¿yj /ip [playerid]");
-            sendTipMessage(playerid, "FUNKCJA: Pokazuje IP wybranego gracza.");
-            return 1;
-        }
-        if(IsPlayerConnected(giveplayerid))
-        {
-            new ip[32];
-            GetPlayerIp(giveplayerid,ip,32);
-            GetPlayerName(giveplayerid, giveplayer, sizeof(giveplayer));
-            format(string, sizeof(string), "-| %s IP: %s |-", giveplayer,ip);
-            SendClientMessage(playerid,COLOR_LIGHTBLUE, string);
-            Log(adminLog, INFO, "Admin %s u¿y³ /ip na graczu %s", GetPlayerLogName(playerid), GetPlayerLogName(giveplayerid));
-        } else
-        {
-            format(string, sizeof(string), "Nie znaleziono gracza o nicku/id %s", params);
-            sendErrorMessage(playerid, string);
-        }
-    } else
+    if (PlayerInfo[playerid][pAdmin] <= 0)
     {
         noAccessMessage(playerid);
+        return 1;
     }
+
+    if(!offline)
+    {
+        new giveplayerid = giveplayer[0];
+
+        if(!IsPlayerConnected(giveplayerid))
+        {
+            sendErrorMessage(playerid, "Nie znaleziono gracza o nicku/id podanym w parametrze.");
+            return 1;
+        }
+
+        GetPlayerName(giveplayerid, giveplayername, sizeof(giveplayername));
+    }
+    else
+    {
+        format(giveplayername, sizeof(giveplayername), "%s", giveplayer);
+    }
+
+    IP5ShowIPListStr(playerid, giveplayername);
+    Log(adminLog, INFO, "Admin %s u¿y³ /ip5 na graczu %s", GetPlayerLogName(playerid), giveplayername);
+
     return 1;
 }
+
+//end

--- a/gamemodes/modules/listaip/commands/listaip_commands.pwn
+++ b/gamemodes/modules/listaip/commands/listaip_commands.pwn
@@ -1,5 +1,5 @@
-//-----------------------------------------------<< Komenda >>-----------------------------------------------//
-//---------------------------------------------------[ ip ]--------------------------------------------------//
+//------------------------------------------<< Generated source >>-------------------------------------------//
+//-----------------------------------------------[ Commands ]------------------------------------------------//
 //----------------------------------------------------*------------------------------------------------------//
 //----[                                                                                                 ]----//
 //----[         |||||             |||||                       ||||||||||       ||||||||||               ]----//
@@ -16,48 +16,26 @@
 //----[  |||             |||||             |||                |||       |||    |||                      ]----//
 //----[                                                                                                 ]----//
 //----------------------------------------------------*------------------------------------------------------//
+// Kod wygenerowany automatycznie narzêdziem Mrucznik CTL
 
-// Opis:
-/*
+// ================= UWAGA! =================
+//
+// WSZELKIE ZMIANY WPROWADZONE DO TEGO PLIKU
+// ZOSTAN¥ NADPISANE PO WYWO£ANIU KOMENDY
+// > mrucznikctl build
+//
+// ================= UWAGA! =================
 
- */
+
+#include <YSI\y_hooks>
+
+//-------<[ include ]>-------
+#include "ip5\ip5.pwn"
 
 
-// Notatki skryptera:
-/*
-
- */
-
-YCMD:ip(playerid, params[], help)
+//-------<[ initialize ]>-------
+hook OnGameModeInit()
 {
-    new string[128];
-    new giveplayer[MAX_PLAYER_NAME];
-
-    if (PlayerInfo[playerid][pAdmin] >= 1)
-    {
-        new giveplayerid;
-        if( sscanf(params, "k<fix>", giveplayerid))
-        {
-            sendTipMessage(playerid, "U¿yj /ip [playerid]");
-            sendTipMessage(playerid, "FUNKCJA: Pokazuje IP wybranego gracza.");
-            return 1;
-        }
-        if(IsPlayerConnected(giveplayerid))
-        {
-            new ip[32];
-            GetPlayerIp(giveplayerid,ip,32);
-            GetPlayerName(giveplayerid, giveplayer, sizeof(giveplayer));
-            format(string, sizeof(string), "-| %s IP: %s |-", giveplayer,ip);
-            SendClientMessage(playerid,COLOR_LIGHTBLUE, string);
-            Log(adminLog, INFO, "Admin %s u¿y³ /ip na graczu %s", GetPlayerLogName(playerid), GetPlayerLogName(giveplayerid));
-        } else
-        {
-            format(string, sizeof(string), "Nie znaleziono gracza o nicku/id %s", params);
-            sendErrorMessage(playerid, string);
-        }
-    } else
-    {
-        noAccessMessage(playerid);
-    }
-    return 1;
+    command_ip5();
+    
 }

--- a/gamemodes/modules/listaip/listaip.def
+++ b/gamemodes/modules/listaip/listaip.def
@@ -1,5 +1,5 @@
-//-----------------------------------------------<< Komenda >>-----------------------------------------------//
-//---------------------------------------------------[ ip ]--------------------------------------------------//
+//-----------------------------------------------<< Defines >>-----------------------------------------------//
+//                                                  listaip                                                  //
 //----------------------------------------------------*------------------------------------------------------//
 //----[                                                                                                 ]----//
 //----[         |||||             |||||                       ||||||||||       ||||||||||               ]----//
@@ -16,48 +16,20 @@
 //----[  |||             |||||             |||                |||       |||    |||                      ]----//
 //----[                                                                                                 ]----//
 //----------------------------------------------------*------------------------------------------------------//
+// Autor: NikodemBanan
+// Data utworzenia: 20.03.2024
 
-// Opis:
-/*
+//
 
- */
+//------------------<[ Define: ]>-------------------
+#define IP_5_LIST_SIZE 2000
+#define IP_5_STR_SIZE 20
+const ip5StrFullSize = 5*IP_5_STR_SIZE;
+#define IP_5_O_STR_SIZE 64
+#define IP_5_DIALOG_ID 3000
 
+//------------------<[ Makra: ]>-------------------
 
-// Notatki skryptera:
-/*
+#define IP_LIST_IP5][%1][%2] IP_LIST_IP5][((%1)*IP_5_STR_SIZE)+(%2)]
 
- */
-
-YCMD:ip(playerid, params[], help)
-{
-    new string[128];
-    new giveplayer[MAX_PLAYER_NAME];
-
-    if (PlayerInfo[playerid][pAdmin] >= 1)
-    {
-        new giveplayerid;
-        if( sscanf(params, "k<fix>", giveplayerid))
-        {
-            sendTipMessage(playerid, "U¿yj /ip [playerid]");
-            sendTipMessage(playerid, "FUNKCJA: Pokazuje IP wybranego gracza.");
-            return 1;
-        }
-        if(IsPlayerConnected(giveplayerid))
-        {
-            new ip[32];
-            GetPlayerIp(giveplayerid,ip,32);
-            GetPlayerName(giveplayerid, giveplayer, sizeof(giveplayer));
-            format(string, sizeof(string), "-| %s IP: %s |-", giveplayer,ip);
-            SendClientMessage(playerid,COLOR_LIGHTBLUE, string);
-            Log(adminLog, INFO, "Admin %s u¿y³ /ip na graczu %s", GetPlayerLogName(playerid), GetPlayerLogName(giveplayerid));
-        } else
-        {
-            format(string, sizeof(string), "Nie znaleziono gracza o nicku/id %s", params);
-            sendErrorMessage(playerid, string);
-        }
-    } else
-    {
-        noAccessMessage(playerid);
-    }
-    return 1;
-}
+//end

--- a/gamemodes/modules/listaip/listaip.hwn
+++ b/gamemodes/modules/listaip/listaip.hwn
@@ -1,5 +1,5 @@
-//-----------------------------------------------<< Komenda >>-----------------------------------------------//
-//---------------------------------------------------[ ip ]--------------------------------------------------//
+//-----------------------------------------------<< Header >>------------------------------------------------//
+//                                                  listaip                                                  //
 //----------------------------------------------------*------------------------------------------------------//
 //----[                                                                                                 ]----//
 //----[         |||||             |||||                       ||||||||||       ||||||||||               ]----//
@@ -16,48 +16,29 @@
 //----[  |||             |||||             |||                |||       |||    |||                      ]----//
 //----[                                                                                                 ]----//
 //----------------------------------------------------*------------------------------------------------------//
+// Autor: NikodemBanan
+// Data utworzenia: 20.03.2024
 
-// Opis:
-/*
+//
 
- */
+#include "YSI_Data/y_hashmap"
 
+//------------------<[ Enumy: ]>--------------------
 
-// Notatki skryptera:
-/*
-
- */
-
-YCMD:ip(playerid, params[], help)
+enum ENUM_IP_5_LIST
 {
-    new string[128];
-    new giveplayer[MAX_PLAYER_NAME];
-
-    if (PlayerInfo[playerid][pAdmin] >= 1)
-    {
-        new giveplayerid;
-        if( sscanf(params, "k<fix>", giveplayerid))
-        {
-            sendTipMessage(playerid, "U¿yj /ip [playerid]");
-            sendTipMessage(playerid, "FUNKCJA: Pokazuje IP wybranego gracza.");
-            return 1;
-        }
-        if(IsPlayerConnected(giveplayerid))
-        {
-            new ip[32];
-            GetPlayerIp(giveplayerid,ip,32);
-            GetPlayerName(giveplayerid, giveplayer, sizeof(giveplayer));
-            format(string, sizeof(string), "-| %s IP: %s |-", giveplayer,ip);
-            SendClientMessage(playerid,COLOR_LIGHTBLUE, string);
-            Log(adminLog, INFO, "Admin %s u¿y³ /ip na graczu %s", GetPlayerLogName(playerid), GetPlayerLogName(giveplayerid));
-        } else
-        {
-            format(string, sizeof(string), "Nie znaleziono gracza o nicku/id %s", params);
-            sendErrorMessage(playerid, string);
-        }
-    } else
-    {
-        noAccessMessage(playerid);
-    }
-    return 1;
+    E_IP5_NAME[32],
+    E_IP5_HASH_DATA[HASH_MAP_DATA],
+    IP_LIST_NUMBER_OF_IP,
+    IP_LIST_IP5[ip5StrFullSize]
 }
+
+//-----------------<[ Zmienne: ]>-------------------
+
+new ip_5_list[IP_5_LIST_SIZE][ENUM_IP_5_LIST];
+new HashMap:ip_5_hashmap<>;
+new ip_5_list_idx = 0;
+
+//------------------<[ Forwardy: ]>--------------------
+
+//end

--- a/gamemodes/modules/listaip/listaip.pwn
+++ b/gamemodes/modules/listaip/listaip.pwn
@@ -84,39 +84,4 @@ stock IP5ShowIPListStr(playerid, playerNick[])
 	}
 }
 
-stock IP5AddTestFakeAddresses()
-{
-	new fakeNick[] = "AAAAAAAAAA";
-	new ipString[32];
-
-	for(new i = 0; i < IP_5_LIST_SIZE; i++)
-	{
-		format(ipString, sizeof(ipString), "%d.%d.%d.%d", random(256), random(256), random(256), random(256));
-		IP5AddIPToList(fakeNick, ipString);
-
-		fakeNick[0]++;
-
-		new fakeNickIdx = 0;
-		while(true)
-		{
-			if(fakeNickIdx == sizeof(fakeNick))
-			{
-				i = IP_5_LIST_SIZE;
-				break;
-			}
-
-			if(fakeNick[fakeNickIdx] == 'Z')
-			{
-				fakeNick[fakeNickIdx] = 'A';
-				fakeNick[fakeNickIdx + 1]++;
-				fakeNickIdx++;
-			}
-			else
-			{
-				break;
-			}
-		}
-	}
-}
-
 //end

--- a/gamemodes/modules/listaip/listaip.pwn
+++ b/gamemodes/modules/listaip/listaip.pwn
@@ -1,0 +1,122 @@
+//-----------------------------------------------<< Source >>------------------------------------------------//
+//                                                  listaip                                                  //
+//----------------------------------------------------*------------------------------------------------------//
+//----[                                                                                                 ]----//
+//----[         |||||             |||||                       ||||||||||       ||||||||||               ]----//
+//----[        ||| |||           ||| |||                      |||     ||||     |||     ||||             ]----//
+//----[       |||   |||         |||   |||                     |||       |||    |||       |||            ]----//
+//----[       ||     ||         ||     ||                     |||       |||    |||       |||            ]----//
+//----[      |||     |||       |||     |||                    |||     ||||     |||     ||||             ]----//
+//----[      ||       ||       ||       ||     __________     ||||||||||       ||||||||||               ]----//
+//----[     |||       |||     |||       |||                   |||    |||       |||                      ]----//
+//----[     ||         ||     ||         ||                   |||     ||       |||                      ]----//
+//----[    |||         |||   |||         |||                  |||     |||      |||                      ]----//
+//----[    ||           ||   ||           ||                  |||      ||      |||                      ]----//
+//----[   |||           ||| |||           |||                 |||      |||     |||                      ]----//
+//----[  |||             |||||             |||                |||       |||    |||                      ]----//
+//----[                                                                                                 ]----//
+//----------------------------------------------------*------------------------------------------------------//
+// Autor: NikodemBanan
+// Data utworzenia: 20.03.2024
+//Opis:
+/*
+	Wyœwietlanie 5 ostatnich adresów IP, na których gra³ gracz pod danym nickiem.
+*/
+
+//
+
+//-----------------<[ Funkcje: ]>-------------------
+
+stock IP5AddIPToList(playerNick[], ip[])
+{
+	if(ip_5_list_idx >= IP_5_LIST_SIZE)
+	{
+		ip_5_list_idx = 0;
+	}
+
+	new idx = HashMap_Get(ip_5_hashmap, playerNick);
+	if(idx == -1)
+	{
+		HashMap_Set(ip_5_hashmap, playerNick, ip_5_list_idx);
+		idx = ip_5_list_idx;
+		ip_5_list[idx][IP_LIST_NUMBER_OF_IP] = 0;
+		ip_5_list_idx++;
+	}
+
+	new numberOfIPs = ip_5_list[idx][IP_LIST_NUMBER_OF_IP];
+
+	if(numberOfIPs == 5)
+	{
+		for(new i = 0; i < 4; i++)
+		{
+			format(ip_5_list[idx][IP_LIST_IP5][i][0], IP_5_STR_SIZE, "%s", ip_5_list[idx][IP_LIST_IP5][i+1][0]);
+		}
+		ip_5_list[idx][IP_LIST_NUMBER_OF_IP] = 4;
+		numberOfIPs = 4;
+	}
+
+	format(ip_5_list[idx][IP_LIST_IP5][numberOfIPs][0], IP_5_STR_SIZE, "%s", ip);
+	ip_5_list[idx][IP_LIST_NUMBER_OF_IP]++;
+
+	return 1;
+}
+
+stock IP5ShowIPListStr(playerid, playerNick[])
+{
+	new ipListStr[IP_5_O_STR_SIZE];
+	new idx = HashMap_Get(ip_5_hashmap, playerNick);
+
+	format(ipListStr, IP_5_O_STR_SIZE, "Adresy IP %s:\n", playerNick);
+	SendClientMessage(playerid, COLOR_LIGHTBLUE, ipListStr);
+
+	if(idx == -1)
+	{
+		SendClientMessage(playerid, COLOR_LIGHTBLUE, "Brak zapisanych adresów.");
+	}
+	else
+	{
+		new numberOfIPs = ip_5_list[idx][IP_LIST_NUMBER_OF_IP];
+		for(new i = numberOfIPs - 1; i >= 0; i--)
+		{
+			format(ipListStr, IP_5_O_STR_SIZE, "%d) %s\n", numberOfIPs - i, ip_5_list[idx][IP_LIST_IP5][i][0]);
+			SendClientMessage(playerid, COLOR_LIGHTBLUE, ipListStr);
+		}
+	}
+}
+
+stock IP5AddTestFakeAddresses()
+{
+	new fakeNick[] = "AAAAAAAAAA";
+	new ipString[32];
+
+	for(new i = 0; i < IP_5_LIST_SIZE; i++)
+	{
+		format(ipString, sizeof(ipString), "%d.%d.%d.%d", random(256), random(256), random(256), random(256));
+		IP5AddIPToList(fakeNick, ipString);
+
+		fakeNick[0]++;
+
+		new fakeNickIdx = 0;
+		while(true)
+		{
+			if(fakeNickIdx == sizeof(fakeNick))
+			{
+				i = IP_5_LIST_SIZE;
+				break;
+			}
+
+			if(fakeNick[fakeNickIdx] == 'Z')
+			{
+				fakeNick[fakeNickIdx] = 'A';
+				fakeNick[fakeNickIdx + 1]++;
+				fakeNickIdx++;
+			}
+			else
+			{
+				break;
+			}
+		}
+	}
+}
+
+//end

--- a/gamemodes/modules/listaip/listaip_callbacks.pwn
+++ b/gamemodes/modules/listaip/listaip_callbacks.pwn
@@ -1,5 +1,5 @@
-//-----------------------------------------------<< Komenda >>-----------------------------------------------//
-//---------------------------------------------------[ ip ]--------------------------------------------------//
+//----------------------------------------------<< Callbacks >>----------------------------------------------//
+//                                                  listaip                                                  //
 //----------------------------------------------------*------------------------------------------------------//
 //----[                                                                                                 ]----//
 //----[         |||||             |||||                       ||||||||||       ||||||||||               ]----//
@@ -16,48 +16,47 @@
 //----[  |||             |||||             |||                |||       |||    |||                      ]----//
 //----[                                                                                                 ]----//
 //----------------------------------------------------*------------------------------------------------------//
-
-// Opis:
+// Autor: NikodemBanan
+// Data utworzenia: 20.03.2024
+//Opis:
 /*
+	Wyœwietlanie 5 ostatnich adresów IP, na których gra³ gracz pod danym nickiem.
+*/
 
- */
+//
 
+#include <YSI\y_hooks>
 
-// Notatki skryptera:
-/*
+//-----------------<[ Callbacki: ]>-----------------
 
- */
-
-YCMD:ip(playerid, params[], help)
+hook OnGameModeInit()
 {
-    new string[128];
-    new giveplayer[MAX_PLAYER_NAME];
-
-    if (PlayerInfo[playerid][pAdmin] >= 1)
-    {
-        new giveplayerid;
-        if( sscanf(params, "k<fix>", giveplayerid))
-        {
-            sendTipMessage(playerid, "U¿yj /ip [playerid]");
-            sendTipMessage(playerid, "FUNKCJA: Pokazuje IP wybranego gracza.");
-            return 1;
-        }
-        if(IsPlayerConnected(giveplayerid))
-        {
-            new ip[32];
-            GetPlayerIp(giveplayerid,ip,32);
-            GetPlayerName(giveplayerid, giveplayer, sizeof(giveplayer));
-            format(string, sizeof(string), "-| %s IP: %s |-", giveplayer,ip);
-            SendClientMessage(playerid,COLOR_LIGHTBLUE, string);
-            Log(adminLog, INFO, "Admin %s u¿y³ /ip na graczu %s", GetPlayerLogName(playerid), GetPlayerLogName(giveplayerid));
-        } else
-        {
-            format(string, sizeof(string), "Nie znaleziono gracza o nicku/id %s", params);
-            sendErrorMessage(playerid, string);
-        }
-    } else
-    {
-        noAccessMessage(playerid);
-    }
-    return 1;
+	HashMap_Init(ip_5_hashmap, ip_5_list, E_IP5_HASH_DATA);
+	IP5AddTestFakeAddresses();
+	return Y_HOOKS_CONTINUE_RETURN_1;
 }
+
+hook OnPlayerConnect(playerid)
+{
+	new ip[32];
+	GetPlayerIp(playerid, ip, sizeof(ip));
+
+	new idx = HashMap_Get(ip_5_hashmap, GetNick(playerid));
+	if(idx != -1)
+	{
+		new numberOfIPs = ip_5_list[idx][IP_LIST_NUMBER_OF_IP];
+		for(new i = 0; i < numberOfIPs; i++)
+		{
+			if(strcmp(ip, ip_5_list[idx][IP_LIST_IP5][i][0]) == 0)
+			{
+				return Y_HOOKS_CONTINUE_RETURN_1;
+			}
+		}
+	}
+
+	IP5AddIPToList(GetNick(playerid), ip);
+
+	return Y_HOOKS_CONTINUE_RETURN_1;
+}
+
+//end

--- a/gamemodes/modules/listaip/listaip_callbacks.pwn
+++ b/gamemodes/modules/listaip/listaip_callbacks.pwn
@@ -32,7 +32,6 @@
 hook OnGameModeInit()
 {
 	HashMap_Init(ip_5_hashmap, ip_5_list, E_IP5_HASH_DATA);
-	IP5AddTestFakeAddresses();
 	return Y_HOOKS_CONTINUE_RETURN_1;
 }
 

--- a/gamemodes/modules/listaip/module.json
+++ b/gamemodes/modules/listaip/module.json
@@ -1,0 +1,11 @@
+{
+    "name": "listaip",
+    "description": "Wyœwietlanie 5 ostatnich adresów IP, na których gra³ gracz pod danym nickiem.",
+    "author": "NikodemBanan",
+    "timers": false,
+    "callbacks": true,
+    "mysql": false,
+    "files": [],
+    "commands": true,
+    "date": "20.03.2024"
+}

--- a/gamemodes/modules/modules.pwn
+++ b/gamemodes/modules/modules.pwn
@@ -70,6 +70,7 @@
 #include "antycheat\antycheat.def"
 #include "komendy\komendy.def"
 #include "choroby\choroby.def"
+#include "listaip\listaip.def"
 
 
 //-------<[ .hwn ]>-------
@@ -115,6 +116,7 @@
 #include "antycheat\antycheat.hwn"
 #include "komendy\komendy.hwn"
 #include "choroby\choroby.hwn"
+#include "listaip\listaip.hwn"
 
 
 //-------<[ .pwn ]>-------
@@ -160,6 +162,7 @@
 #include "antycheat\antycheat.pwn"
 #include "komendy\komendy.pwn"
 #include "choroby\choroby.pwn"
+#include "listaip\listaip.pwn"
 
 
 //-------<[ timers ]>-------
@@ -220,7 +223,7 @@
 #include "zlodziej_aut\zlodziej_aut_callbacks.pwn"
 #include "antycheat\antycheat_callbacks.pwn"
 #include "choroby\choroby_callbacks.pwn"
-
+#include "listaip\listaip_callbacks.pwn"
 
 //-------<[ commands ]>-------
 #include "frakcje\commands\frakcje_commands.pwn"
@@ -253,3 +256,4 @@
 #include "antycheat\commands\antycheat_commands.pwn"
 #include "komendy\commands\komendy_commands.pwn"
 #include "choroby\commands\choroby_commands.pwn"
+#include "listaip\commands\listaip_commands.pwn"

--- a/gamemodes/system/funkcje.pwn
+++ b/gamemodes/system/funkcje.pwn
@@ -2218,27 +2218,6 @@ IsAPolicja(playerid)
 	return 0;
 }
 
-IsAFakeKonto(playerid)
-{
-	if(IsPlayerConnected(playerid))
-	{
-	    new nick[MAX_PLAYER_NAME];
-		GetPlayerName(playerid, nick, sizeof(nick));
-		if(strcmp(nick,"Gniewomir_Wonsz", false) == 0 || strcmp(nick,"Filemon_Paprotka", false) == 0 || strcmp(nick,"Julia_Wisefield", false) == 0)
-		{
-		    return 1;
-		}
-	
-		new ip[32];
-		GetPlayerIp(playerid,ip,sizeof(ip));
-		if(strcmp(ip,"185.6.30.124", false) == 0)
-		{
-			return 1;
-		}
-	}
-	return 0;
-}
-
 IsAPrzestepca(playerid)
 {
 	if(IsPlayerConnected(playerid))


### PR DESCRIPTION
 Dodanie komendy /ip5, pozwalającej na wyświetlanie 5 ostatnich adresów IP, z których korzystał gracz pod danym nickiem (nie jest zachowywane po restarcie serwa).
 
Na prośbę administracji.