### PR TITLE
Kill command negative money fix

### DIFF
--- a/gamemodes/modules/bw/bw.pwn
+++ b/gamemodes/modules/bw/bw.pwn
@@ -36,7 +36,7 @@ BW_OnDialogResponse(playerid, dialogid, response, listitem, inputtext[])
 			ChatMe(playerid, "umiera na wskutek odniesionych obra¿eñ ((MemoryKill))");
 			SetPlayerHealth(playerid, 0.0);
 
-    		new moneyLost = floatround(kaska[playerid] * 0.02, floatround_ceil);
+			new moneyLost = floatround(kaska[playerid] * 0.02, floatround_ceil);
 			if (moneyLost < 0) {
 				return Y_HOOKS_CONTINUE_RETURN_0;
 			}

--- a/gamemodes/modules/bw/bw.pwn
+++ b/gamemodes/modules/bw/bw.pwn
@@ -33,11 +33,15 @@ BW_OnDialogResponse(playerid, dialogid, response, listitem, inputtext[])
 	{
 		if(response) 
 		{
-    		new moneyLost = floatround(kaska[playerid] * 0.02, floatround_ceil);
-			ZabierzKase(playerid, moneyLost);
-			Log(payLog, INFO, "%s upuœci³ %d$ na skutek œmierci", GetPlayerLogName(playerid), moneyLost);
 			ChatMe(playerid, "umiera na wskutek odniesionych obra¿eñ ((MemoryKill))");
 			SetPlayerHealth(playerid, 0.0);
+
+    		new moneyLost = floatround(kaska[playerid] * 0.02, floatround_ceil);
+    		if (moneyLost < 0) {
+    		    return Y_HOOKS_CONTINUE_RETURN_0;
+    		}
+			ZabierzKase(playerid, moneyLost);
+			Log(payLog, INFO, "%s upuœci³ %d$ na skutek œmierci", GetPlayerLogName(playerid), moneyLost);
 
 			new Float:x, Float:y, Float:z;
 			GetPlayerPos(playerid, x, y, z);

--- a/gamemodes/modules/bw/bw.pwn
+++ b/gamemodes/modules/bw/bw.pwn
@@ -37,9 +37,9 @@ BW_OnDialogResponse(playerid, dialogid, response, listitem, inputtext[])
 			SetPlayerHealth(playerid, 0.0);
 
     		new moneyLost = floatround(kaska[playerid] * 0.02, floatround_ceil);
-    		if (moneyLost < 0) {
-    		    return Y_HOOKS_CONTINUE_RETURN_0;
-    		}
+			if (moneyLost < 0) {
+				return Y_HOOKS_CONTINUE_RETURN_0;
+			}
 			ZabierzKase(playerid, moneyLost);
 			Log(payLog, INFO, "%s upuœci³ %d$ na skutek œmierci", GetPlayerLogName(playerid), moneyLost);
 

--- a/gamemodes/modules/bw/commands/kill/kill_impl.pwn
+++ b/gamemodes/modules/bw/commands/kill/kill_impl.pwn
@@ -32,6 +32,9 @@ command_kill_Impl(playerid)
 
     new message[128];
     new moneyLost = floatround(kaska[playerid] * 0.02, floatround_ceil);
+    if (moneyLost < 0) {
+        moneyLost = 0;
+    }
     format(message, sizeof(message), "Czy na pewno chcesz uœmierciæ (memory kill) swoj¹ postaæ?\nStracisz %d$ ze swojego portfela.", moneyLost);
     ShowPlayerDialogEx(playerid, DIALOG_ID_KILL, DIALOG_STYLE_MSGBOX, "Uœmiercenie postaci", message, "Akceptuj", "Anuluj");
     return 1;


### PR DESCRIPTION
Zabezpieczono komendę `/kill` przed tworzeniem pickupów z ujemnymi kwotami