### PR TITLE
fix nick regex i usun bana za 10kk na 1lvl

### DIFF
--- a/gamemodes/Mrucznik-RP.pwn
+++ b/gamemodes/Mrucznik-RP.pwn
@@ -3497,12 +3497,6 @@ PayDay()
 					{
 					    PlayerInfo[i][pBP]--;
 					}
-					if(((kaska[i] >= 10000000 || PlayerInfo[i][pAccount] >= 10000000) && PlayerInfo[i][pLevel] <= 2) && !DEVELOPMENT)
-					{
-						MruMySQL_Banuj(i, "10MLN i 1 lvl");
-						Log(punishmentLog, INFO, "%s dosta³ bana za 10MLN i 1 lvl (Portfel: %d$, Bank: %d$)", GetPlayerLogName(i), kaska[i], PlayerInfo[i][pAccount]);
-						KickEx(i, "podejrzenie bugowania pieniêdzy");
-					}
 					if(IsPlayerPremiumOld(i))
 					{
 					    PlayerInfo[i][pPayDayHad] += 1;

--- a/gamemodes/system/definicje.pwn
+++ b/gamemodes/system/definicje.pwn
@@ -551,7 +551,7 @@
 //AJ powód
 #define MAX_AJ_REASON 64
 
-#define NICK_REGEX "^(Le)?[A-Z]{1}[a-z]{1,}(_[A-Z]{1}[a-z]{1,}([A-HJ-Z]{1}[a-z]{1,})?){1,2}$"
+#define NICK_REGEX "^[A-Z][a-z]+([A-Z][a-z]+)?(_[A-Z][a-z]+([A-Z][a-z]+)?){1,2}$"
 
 // Y_SAFERETURN ! ! !
 forward _SafeReturnCode_(dest[], src[], bytes);


### PR DESCRIPTION
1. poprawilem regex na nick zeby teraz (w teorii bo nie testowalem) pozwalal na dwuczlonowe imiona (LeBron) i nazwiska (McDonald). to jest cos co zrobilem kilka miesiecy temu ale nie zdazylem zrobic pr bo serwer wtedy juz umarl
2. usunalem bana za 10kk na 1lvl bo kilka osob na discordzie juz go dostalo za lowienie rybek a ekonomia i tak jest wenezuelska