### PR TITLE
Update gotomark_impl.pwn

### DIFF
--- a/gamemodes/modules/komendy/commands/gotomark/gotomark_impl.pwn
+++ b/gamemodes/modules/komendy/commands/gotomark/gotomark_impl.pwn
@@ -18,6 +18,7 @@
 //----------------------------------------------------*------------------------------------------------------//
 // Autor: mrucznik
 // Data utworzenia: 15.09.2024
+// Aktualizacja: 20.04.2025 by Sahari
 
 
 //
@@ -27,7 +28,7 @@ command_gotomark_Impl(playerid)
 {
     if(IsPlayerConnected(playerid))
     {
-		if (PlayerInfo[playerid][pAdmin] >= 1 || IsAScripter(playerid))
+		if (PlayerInfo[playerid][pAdmin] >= 1 || IsAScripter(playerid) || Zaufany(playerid))
 		{
 			SetPlayerInterior(playerid,0);
 			if (GetPlayerState(playerid) == 2)
@@ -39,7 +40,7 @@ command_gotomark_Impl(playerid)
 			{
 				SetPlayerPos(playerid, TeleportDest[playerid][0],TeleportDest[playerid][1],TeleportDest[playerid][2]);
 			}
-			sendTipMessageEx(playerid, COLOR_GRAD1, "Zosta³eœ teleportowany!");
+			sendTipMessageEx(playerid, COLOR_GRAD1, "ZostaÂ³eÅ“ teleportowany!");
 		}
 		else
 		{


### PR DESCRIPTION
Dodano możliwość używania komend przez ZG lvl 1 i 10
/mark
/gotomark
/flip
/gotols
/aj
/unaj
/kick
/fixveh
/tankveh
/unbw
/respawnplayer
/respawncar
/freeze
/setvw
/getvw
/pogodaall
/tod
/bp
/getcar
/unbp
/tp
/undermogan
/zweryfikuj
/paj 
/forum
/pojazdygracza
/obrazenia
/gethere

Dla ZG lvl 10 
/logoutpl
/gotocar

Dodano wszystko + dla p@
/gotoszpital
/gotosf
/gotolv
/gotobank
/gotoin
/rapidfly

Dla 4999lvl admin 
/restart

Zaktualizowano komende /ah.
Dodano do listy /admins zaufanych graczy.
